### PR TITLE
Oauth setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ address (you can get it with `ifconfig` on Linux): suppose this is
 and put it on a network called `seek_default`.
 
 ```
+docker network create seek_default
 docker run -d --network seek_default -p 3000:3000 \
   -v /tmp/etc_nginx:/etc/nginx:ro -v /tmp/certs:/nginx/certs:ro \
   --add-host lm.org:192.168.1.167 --name wfhub fairdom/seek:workflow

--- a/README.md
+++ b/README.md
@@ -231,3 +231,9 @@ should be redirected to a WorkflowHub page that asks you to authorize
 LifeMonitor to use your account. Click on "Authorize" and you should land on a
 LifeMonitor page that confirms you are logged in and displays your login
 details.
+
+### Additional notes on WorkflowHub configuration
+
+In order to get correct URLs from the WorkflowHub API, you need to set the base URL. Go to Server admin > Settings and set "Site base URL" to https://lm.org:3000.
+
+To enable workflows, go to Server admin > Enable/disable features and click on "Workflows enabled". You can set "CWL Viewer URL" to `https://view.commonwl.org/`.

--- a/README.md
+++ b/README.md
@@ -227,5 +227,7 @@ the callback url for LifeMonitor. Confirm authorization on the next page. You
 should get an OAuth error. This is currently a [known
 bug](https://github.com/crs4/life_monitor/issues/30), so ignore it. Go to
 https://lm.org:8443, click on "Log in" and choose to log in with Seek. You
-should be redirected to https://lm.org:3000/login, where you can log in with
-your WorkflowHub username and password.
+should be redirected to a WorkflowHub page that asks you to authorize
+LifeMonitor to use your account. Click on "Authorize" and you should land on a
+LifeMonitor page that confirms you are logged in and displays your login
+details.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ the "workflow" branch of https://github.com/seek4science/seek) and rebuild the
 image locally, or overwrite the `/etc/nginx` dir on the WorkflowHub container
 with a bind mount. For instance, suppose you have copied the contents of
 `/etc/nginx` from the WorkflowHub container to `/tmp/etc_nginx`. Also suppose
-our certificates are on /tmp/certs. Finally, we're going to map `lm.org` (the
+our certificates are on `/tmp/certs`. Finally, we're going to map `lm.org` (the
 hostname in the self-signed certificates) to the physical host's (internal) IP
 address (you can get it with `ifconfig` on Linux): suppose this is
 `192.168.1.167`. We're going to run WorkflowHub on a single Docker container,

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Apply the following modifications to the WorkflowHub `nginx.conf` file:
 ```
 
 You can change `docker/nginx.conf` on the WorkflowHub git repo (currently on
-the "workflow" branch of git@github.com:seek4science/seek.git) and rebuild the
+the "workflow" branch of https://github.com/seek4science/seek) and rebuild the
 image locally, or overwrite the `/etc/nginx` dir on the WorkflowHub container
 with a bind mount. For instance, suppose you have copied the contents of
 `/etc/nginx` from the WorkflowHub container to `/tmp/etc_nginx`. Also suppose

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ WorkflowHub Docker container.
 Apply the following modifications to the WorkflowHub `nginx.conf` file:
 
 
-```
+```diff
 @@ -63,7 +63,10 @@ http {
          # gzip_http_version 1.1;
  
@@ -200,15 +200,16 @@ SEEK_ACCESS_TOKEN_URL="https://lm.org:3000/oauth/token"
 In the LifeMonitor `docker-compose-template.yml`, in the `lm` service section,
 map the lm.org host to the above IP:
 
+```yaml
   lm:
     [...]
     extra_hosts:
       - "lm.org:192.168.1.167"
-
+```
 
 Set the network name to `seek_default`:
 
-```
+```yaml
 networks:
   life_monitor:
     name: seek_default

--- a/README.md
+++ b/README.md
@@ -237,3 +237,11 @@ details.
 In order to get correct URLs from the WorkflowHub API, you need to set the base URL. Go to Server admin > Settings and set "Site base URL" to https://lm.org:3000.
 
 To enable workflows, go to Server admin > Enable/disable features and click on "Workflows enabled". You can set "CWL Viewer URL" to `https://view.commonwl.org/`.
+
+### WorkflowHub API calls with requests when using self-signed certificates
+
+If you are using [requests](https://requests.readthedocs.io/en/master/), note
+that to interact with the WorkflowHub configured with a self-signed
+certificate you need to add `verify=False` to the calls. See
+[this](https://stackoverflow.com/questions/30405867/how-to-get-python-requests-to-trust-a-self-signed-ssl-certificate)
+for instance.

--- a/README.md
+++ b/README.md
@@ -69,20 +69,6 @@ The API key will be printed on the console.  See the
 [CLI](#Command-line-interface) section for pointers on how to call it.
 
 
-### Registering LifeMonitor as a client application on WorkflowHub
-
-On the WorkflowHub web interface, click on the user name on the top right,
-then go to "My Profile"; on the profile page, click "Actions" on the right,
-then choose "API Applications"; now click on "New Application" on the right
-and fill out the form. Choose a name, set Redirect URI to
-https://localhost:8443/oauth2/auth/seek, activate Confidential and Scopes >
-Read.
-
-This can be done for any user (e.g., create a service user on the
-WorkflowHub), all that matters to LifeMonitor is the OAuth params (Client ID,
-Client Secret, etc.) provided after registration.
-
-
 ## Command line interface
 
 To access the command line interface, you need to execute `flask ...` from the
@@ -125,3 +111,119 @@ containers will be created attached to that same network and the services will
 see each other.  You will also neet to set `WORKFLOW_REGISTRY_URL` appropriately
 in `settings.conf`.
 
+
+## Setting up WorkflowHub and LifeMonitor with OAuth2 login
+
+Bring up WorkflowHub and LifeMonitor with OAuth2 enabled on a single physical
+host. Note that this is an example walkthrough for documentation purposes. For
+a production deployment you might want to change something, e.g., avoid using
+self-signed certificates.
+
+### Bringing up WorkflowHub with HTTPS configuration
+
+In this example we're going to use the same self-signed certificates generated
+by our Makefile, which we're going to mount on `/nginx/certs` on the
+WorkflowHub Docker container.
+
+Apply the following modifications to the WorkflowHub `nginx.conf` file:
+
+
+```
+@@ -63,7 +63,10 @@ http {
+         # gzip_http_version 1.1;
+ 
+         server {
+-               listen 3000;
++               listen 3000 ssl default_server;
++               ssl_certificate /nginx/certs/lm.crt;
++               ssl_certificate_key /nginx/certs/lm.key;
+                root /seek/public;
+                client_max_body_size 2G;
+                location / {
+@@ -72,6 +75,7 @@ http {
+                     proxy_set_header   X-Real-IP $remote_addr;
+                     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+                     proxy_set_header   X-Forwarded-Host $server_name;
++                    proxy_set_header   X-Forwarded-Proto $scheme;
+                }
+                 location ^~ /(assets)/  {
+                                gzip_static on;
+```
+
+You can change `docker/nginx.conf` on the WorkflowHub git repo (currently on
+the "workflow" branch of git@github.com:seek4science/seek.git) and rebuild the
+image locally, or overwrite the `/etc/nginx` dir on the WorkflowHub container
+with a bind mount. For instance, suppose you have copied the contents of
+`/etc/nginx` from the WorkflowHub container to `/tmp/etc_nginx`. Also suppose
+our certificates are on /tmp/certs. Finally, we're going to map `lm.org` (the
+hostname in the self-signed certificates) to the physical host's (internal) IP
+address (you can get it with `ifconfig` on Linux): suppose this is
+`192.168.1.167`. We're going to run WorkflowHub on a single Docker container,
+and put it on a network called `seek_default`.
+
+```
+docker run -d --network seek_default -p 3000:3000 \
+  -v /tmp/etc_nginx:/etc/nginx:ro -v /tmp/certs:/nginx/certs:ro \
+  --add-host lm.org:192.168.1.167 --name wfhub fairdom/seek:workflow
+```
+
+Also add a `192.168.1.167 lm.org` entry to the physical host's `/etc/hosts`.
+
+### Register on WorkflowHub
+
+Since WorkflowHub is starting for the first time, we need to register a first
+admin user. Go to https://lm.org:3000 and fill out the forms.
+
+### Registering LifeMonitor as a client application on WorkflowHub
+
+On the WorkflowHub web interface, click on the user name on the top right,
+then go to "My Profile"; on the profile page, click "Actions" on the right,
+then choose "API Applications"; now click on "New Application" on the right
+and fill out the form. Choose a name, set Redirect URI to
+https://lm.org:8443/oauth2/auth/seek, activate Confidential and Scopes >
+Read, then submit the form.
+
+This can be done for any user (e.g., a service user could have been created on
+the WorkflowHub just for this), all that matters to LifeMonitor is the OAuth
+params provided after registration. Specifically, copy the following to
+`settings.conf` in the LifeMonitor repo: "Application UID" to `SEEK_CLIENT_ID`
+and "Secret" to `SEEK_CLIENT_SECRET`. Set the other WorkflowHub params to:
+
+```
+SEEK_API_BASE_URL="https://lm.org:3000"
+SEEK_AUTHORIZE_URL="https://lm.org:3000/oauth/authorize"
+SEEK_ACCESS_TOKEN_URL="https://lm.org:3000/oauth/token"
+```
+
+### Configure LifeMonitor's docker-compose file and start the service
+
+In the LifeMonitor `docker-compose-template.yml`, in the `lm` service section,
+map the lm.org host to the above IP:
+
+  lm:
+    [...]
+    extra_hosts:
+      - "lm.org:192.168.1.167"
+
+
+Set the network name to `seek_default`:
+
+```
+networks:
+  life_monitor:
+    name: seek_default
+    external: true
+```
+
+Start the service with `make startdev`.
+
+
+### Authorizing LifeMonitor as a client application and logging in
+
+Now go back to the WorkflowHub web UI and click on "Authorize" on the right of
+the callback url for LifeMonitor. Confirm authorization on the next page. You
+should get an OAuth error. This is currently a [known
+bug](https://github.com/crs4/life_monitor/issues/30), so ignore it. Go to
+https://lm.org:8443, click on "Log in" and choose to log in with Seek. You
+should be redirected to https://lm.org:3000/login, where you can log in with
+your WorkflowHub username and password.


### PR DESCRIPTION
Adds a walkthrough on setting up WorkflowHub + LifeMonitor with OAuth enabled on a single physical host.