### PR TITLE
Update RO-Crate-related code

### DIFF
--- a/interaction_experiments/check_cwl.py
+++ b/interaction_experiments/check_cwl.py
@@ -23,37 +23,16 @@ Execute a CWL workflow from a crate and check results.
 """
 
 import argparse
-import json
 import os
 import shutil
 import subprocess
 import tempfile
 
 import yaml
+import lifemonitor.ro_crate as roc
 import lifemonitor.test_metadata as tm
 
 YamlDumper = getattr(yaml, "CDumper", getattr(yaml, "Dumper"))
-METADATA_BASENAME = "ro-crate-metadata.jsonld"
-
-
-# https://github.com/workflowhub-eu/about/wiki/Workflow-RO-Crate
-# https://researchobject.github.io/ro-crate/1.0/
-def parse_metadata(crate_dir):
-    fn = os.path.join(crate_dir, METADATA_BASENAME)
-    if not os.path.isfile(fn):
-        raise RuntimeError(f"{METADATA_BASENAME} not found in {crate_dir}")
-    with open(fn, "rt") as f:
-        json_data = json.load(f)
-    entities = {_["@id"]: _ for _ in json_data["@graph"]}
-    md_desc = entities[METADATA_BASENAME]
-    root = entities[md_desc["about"]["@id"]]
-    main = entities[root["mainEntity"]["@id"]]
-    assert main["@type"] == ["File", "SoftwareSourceCode", "Workflow"]
-    # Dataset @id SHOULD end with /
-    return {
-        "main": main["@id"],
-        "test": "test" in [_.rstrip("/") for _ in entities]
-    }
 
 
 # pip install planemo
@@ -82,7 +61,7 @@ def check_workflow(crate_dir, metadata, tests):
 
 
 def main(args):
-    metadata = parse_metadata(args.crate_dir)
+    metadata = roc.parse_metadata(args.crate_dir)
     test_dir = os.path.join(args.crate_dir, "test")
     if not os.path.isdir(test_dir):
         if metadata["test"]:

--- a/interaction_experiments/check_cwl.py
+++ b/interaction_experiments/check_cwl.py
@@ -36,11 +36,11 @@ YamlDumper = getattr(yaml, "CDumper", getattr(yaml, "Dumper"))
 
 
 # pip install planemo
-def check_workflow(crate_dir, metadata, tests):
+def check_workflow(crate_dir, wf_path, tests):
     wd = tempfile.mkdtemp(prefix="check_cwl_")
     crate_dir_bn = os.path.basename(crate_dir)
     tmp_crate_dir = os.path.join(wd, crate_dir_bn)
-    wf_fn = os.path.join(tmp_crate_dir, metadata["main"])
+    wf_fn = os.path.join(tmp_crate_dir, wf_path.relative_to(crate_dir))
     wf_bn = os.path.basename(wf_fn)
     shutil.copytree(crate_dir, tmp_crate_dir)
     head, tail = os.path.splitext(wf_bn)
@@ -61,17 +61,13 @@ def check_workflow(crate_dir, metadata, tests):
 
 
 def main(args):
-    metadata = roc.parse_metadata(args.crate_dir)
-    test_dir = os.path.join(args.crate_dir, "test")
-    if not os.path.isdir(test_dir):
-        if metadata["test"]:
-            raise RuntimeError("test dir not found")
-        else:
-            print("crate has no tests, nothing to do")
-            return
+    wf_path, test_dir = roc.parse_metadata(args.crate_dir)
+    if not test_dir:
+        print("crate has no tests, nothing to do")
+        return
     cfg_fn = os.path.join(test_dir, "test-metadata.json")
     tests = tm.read_tests(cfg_fn, abs_paths=True)
-    check_workflow(args.crate_dir, metadata, tests)
+    check_workflow(args.crate_dir, wf_path, tests)
 
 
 if __name__ == "__main__":

--- a/interaction_experiments/check_galaxy.py
+++ b/interaction_experiments/check_galaxy.py
@@ -23,38 +23,17 @@ Execute a Galaxy workflow from a crate and check results.
 """
 
 import argparse
-import json
 import os
 import shutil
 import subprocess
 import tempfile
 
 import yaml
+import lifemonitor.ro_crate as roc
 import lifemonitor.test_metadata as tm
 
 YamlDumper = getattr(yaml, "CDumper", getattr(yaml, "Dumper"))
-METADATA_BASENAME = "ro-crate-metadata.jsonld"
 GALAXY_IMG = "bgruening/galaxy-stable:20.05"
-
-
-# https://github.com/workflowhub-eu/about/wiki/Workflow-RO-Crate
-# https://researchobject.github.io/ro-crate/1.0/
-def parse_metadata(crate_dir):
-    fn = os.path.join(crate_dir, METADATA_BASENAME)
-    if not os.path.isfile(fn):
-        raise RuntimeError(f"{METADATA_BASENAME} not found in {crate_dir}")
-    with open(fn, "rt") as f:
-        json_data = json.load(f)
-    entities = {_["@id"]: _ for _ in json_data["@graph"]}
-    md_desc = entities[METADATA_BASENAME]
-    root = entities[md_desc["about"]["@id"]]
-    main = entities[root["mainEntity"]["@id"]]
-    assert main["@type"] == ["File", "SoftwareSourceCode", "Workflow"]
-    # Dataset @id SHOULD end with /
-    return {
-        "main": main["@id"],
-        "test": "test" in [_.rstrip("/") for _ in entities]
-    }
 
 
 def dump_instances(tests):
@@ -94,7 +73,7 @@ def check_workflow(wf_fn, tests):
 
 
 def main(args):
-    metadata = parse_metadata(args.crate_dir)
+    metadata = roc.parse_metadata(args.crate_dir)
     wf_fn = os.path.join(args.crate_dir, metadata["main"])
     test_dir = os.path.join(args.crate_dir, "test")
     if not os.path.isdir(test_dir):

--- a/interaction_experiments/check_galaxy.py
+++ b/interaction_experiments/check_galaxy.py
@@ -73,19 +73,14 @@ def check_workflow(wf_fn, tests):
 
 
 def main(args):
-    metadata = roc.parse_metadata(args.crate_dir)
-    wf_fn = os.path.join(args.crate_dir, metadata["main"])
-    test_dir = os.path.join(args.crate_dir, "test")
-    if not os.path.isdir(test_dir):
-        if metadata["test"]:
-            raise RuntimeError("test dir not found")
-        else:
-            print("crate has no tests, nothing to do")
-            return
+    wf_path, test_dir = roc.parse_metadata(args.crate_dir)
+    if not test_dir:
+        print("crate has no tests, nothing to do")
+        return
     cfg_fn = os.path.join(test_dir, "test-metadata.json")
     tests = tm.read_tests(cfg_fn, abs_paths=True)
     dump_instances(tests)
-    check_workflow(wf_fn, tests)
+    check_workflow(wf_path, tests)
 
 
 if __name__ == "__main__":

--- a/lifemonitor/ro_crate.py
+++ b/lifemonitor/ro_crate.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2020 CRS4
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""\
+RO-Crate support.
+
+TODO: get rid of this module and depend on ro-crate-py instead once it's stable.
+
+https://www.researchobject.org/ro-crate
+https://github.com/workflowhub-eu/about/wiki/Workflow-RO-Crate
+https://github.com/ResearchObject/ro-crate-py
+"""
+
+import json
+from pathlib import Path
+
+METADATA_BASENAME = "ro-crate-metadata.json"  # since RO-Crate 1.1
+LEGACY_METADATA_BASENAME = "ro-crate-metadata.jsonld"
+
+
+def find_root_entity(entity_map):
+    for entity in entity_map.values():
+        try:
+            conforms_to = entity["conformsTo"]
+        except KeyError:
+            continue
+        if conforms_to.get("@id", "").startswith("https://w3id.org/ro/crate/"):
+            try:
+                root_id = entity["about"]["@id"]
+            except (KeyError, TypeError):
+                continue
+            if root_id in entity_map:
+                return entity_map[root_id]
+    for name in METADATA_BASENAME, LEGACY_METADATA_BASENAME:
+        try:
+            root_id = entity_map[name]["about"]["@id"]
+        except (KeyError, TypeError):
+            continue
+        if root_id in entity_map:
+            return entity_map[root_id]
+    raise ValueError("root data entity not found in crate")
+
+
+def parse_metadata(crate_dir):
+    crate_dir = Path(crate_dir)
+    metadata_path = crate_dir / METADATA_BASENAME
+    if not metadata_path.is_file():
+        metadata_path = crate_dir / LEGACY_METADATA_BASENAME
+        if not metadata_path.is_file():
+            raise RuntimeError(f"{metadata_path} not found")
+    with open(metadata_path, "rt") as f:
+        json_data = json.load(f)
+    entities = {_["@id"]: _ for _ in json_data["@graph"]}
+    root = find_root_entity(entities)
+    print("root:", root)
+    main = entities[root["mainEntity"]["@id"]]
+    assert main["@type"] == ["File", "SoftwareSourceCode", "Workflow"]
+    # Dataset @id SHOULD end with /
+    return {
+        "main": main["@id"],
+        "test": "test" in [_.rstrip("/") for _ in entities]
+    }


### PR DESCRIPTION
Updates the code for interacting with RO-Crates to support both the upcoming RO-Crate 1.1 release and the now-current-soon-legacy RO-Crate 1.0. At the moment, WorkflowHub is generating 1.1 crates for workflows uploaded as single files, but legacy 1.0 crates are still around (e.g., from old crate uploads) and probably will be for a while even after the official release of RO-Crate 1.1.

The code has been moved from the workflow check example scripts to an `ro_crate` module. Once [ro-crate-py](https://github.com/ResearchObject/ro-crate-py) is stable enough, we should be able to use that instead.