### PR TITLE
Update test_metadata module according to the latest test spec

### DIFF
--- a/lifemonitor/test_metadata.py
+++ b/lifemonitor/test_metadata.py
@@ -209,13 +209,10 @@ def get_roc_suites(crate):
             ]
         }
     """
-    if not crate.test_dir:
-        return None
-    about = crate.test_dir["about"]
-    if not about:
+    if not crate.test_suites:
         return None
     rval = {}
-    for suite in about:
+    for suite in crate.test_suites:
         suite_data = {
             "roc_suite": suite.id,
             "name": suite.name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ connexion[swagger-ui]==2.7.0
 python-jenkins==1.7.0
 pytest-mock==3.3.1
 flask-shell-ipython==0.4.1
-rocrate~=0.3.1
+rocrate~=0.4.0


### PR DESCRIPTION
See https://github.com/ResearchObject/ro-crate-py/pull/55 and the [corresponding changes in the test metadata spec](https://github.com/crs4/life_monitor/wiki/Workflow-Testing-RO-Crate/_compare/a620721598ed65749c95ba8aeadbddb31e50f328...29d1ed97ebd35ab26f8f151e4799e02b3bb0ad58).

For now, only the `test_metadata` module has been changed (allowing to support the new format). RO-Crate metadata files in tests and examples have not been changed (the new ro-crate-py version supports the previous way of referencing suites from a `test` dir).