### PR TITLE
Fix/refresh token

### DIFF
--- a/docker-compose.extra.yml
+++ b/docker-compose.extra.yml
@@ -11,6 +11,7 @@ services:
       - ./certs/lm.crt:/certs/lm.crt:ro
       - ./certs/lm.key:/certs/lm.key:ro
       - ./tests/config/registries/seek/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./tests/config/registries/seek/doorkeeper.rb:/seek/config/initializers/doorkeeper.rb
     networks:
       - life_monitor
 

--- a/lifemonitor/auth/oauth2/client/controllers.py
+++ b/lifemonitor/auth/oauth2/client/controllers.py
@@ -132,7 +132,7 @@ class AuthorizatonHandler:
                              provider.name, user_info.sub, identity)
                 # update identity with the last token and userinfo
                 identity.user_info = user_info.to_dict()
-                identity.set_token(token)
+                identity.token = token
                 logger.debug("Update identity token: %r -> %r", identity.token, token)
             except OAuthIdentityNotFoundException:
                 logger.debug("Not found OAuth identity <%r,%r>", provider.name, user_info.sub)

--- a/lifemonitor/auth/oauth2/client/models.py
+++ b/lifemonitor/auth/oauth2/client/models.py
@@ -71,7 +71,7 @@ class OAuth2Token(OAuth2TokenBase):
         return expires_at < time.time()
 
     @property
-    def threashold(self):
+    def threshold(self):
         try:
             return int(current_app.config['OAUTH2_REFRESH_TOKEN_BEFORE_EXPIRATION'])
         except Exception as e:
@@ -84,7 +84,7 @@ class OAuth2Token(OAuth2TokenBase):
         expires_at = self.get('expires_at')
         if not expires_at:
             return None
-        return (expires_at - self.threashold) < time.time()
+        return (expires_at - self.threshold) < time.time()
 
 
 class OAuthUserProfile:

--- a/lifemonitor/auth/oauth2/client/models.py
+++ b/lifemonitor/auth/oauth2/client/models.py
@@ -163,7 +163,7 @@ class OAuthIdentity(models.ExternalServiceAccessAuthorization, ModelMixin):
     def token(self, token: dict):
         self._token = token
 
-    def fetch_token(self, auto_refresh=True):
+    def fetch_token(self):
         # enable dynamic refresh only if the identity
         # has been already stored in the database
         if inspect(self).persistent:
@@ -174,10 +174,8 @@ class OAuthIdentity(models.ExternalServiceAccessAuthorization, ModelMixin):
             # the token should be refreshed
             # if it is expired or close to expire (i.e., n secs before expiration)
             if token.to_be_refreshed():
-                if not auto_refresh:
-                    logger.warning("The token should be refreshed but `auto_refresh` is disabled")
-                elif 'refresh_token' not in token:
-                    logger.warning("The token should be refreshed but no refresh token is associated with the token")
+                if 'refresh_token' not in token:
+                    logger.debug("The token should be refreshed but no refresh token is associated with the token")
                 else:
                     logger.debug("Trying to refresh the token...")
                     oauth2session = OAuth2Session(

--- a/lifemonitor/auth/oauth2/client/models.py
+++ b/lifemonitor/auth/oauth2/client/models.py
@@ -198,14 +198,15 @@ class OAuth2Registry(OAuth):
         super().register(client_config.name, overwrite=True, client_cls=OAuth2Client)
 
     @staticmethod
-    def fetch_token(name):
+    def fetch_token(name, user=None):
+        user = user or current_user
         logger.debug("NAME: %s", name)
         logger.debug("CURRENT APP: %r", current_app.config)
         api_key = current_app.config.get("{}_API_KEY".format(name.upper()), None)
         if api_key:
             logger.debug("FOUND an API KEY for the OAuth Service '%s': %s", name, api_key)
             return {"access_token": api_key}
-        identity = OAuthIdentity.find_by_user_id(current_user.id, name)
+        identity = OAuthIdentity.find_by_user_id(user.id, name)
         logger.debug("The token: %r", identity.token)
         return OAuth2Token(identity.token)
 

--- a/lifemonitor/auth/oauth2/client/models.py
+++ b/lifemonitor/auth/oauth2/client/models.py
@@ -212,12 +212,18 @@ class OAuth2Registry(OAuth):
 
     @staticmethod
     def update_token(name, token, refresh_token=None, access_token=None):
-        if access_token or refresh_token:
-            identity = OAuthIdentity.find_by_user_id(current_user.id, name)
-        else:
-            return
+        if access_token:
+            logger.debug("Fetching token by access_token...")
+            identity = OAuthIdentity.query.filter(
+                OAuthIdentity.token['access_token'] == access_token).one()
+        elif refresh_token:
+            logger.debug("Fetching token by refresh_token...")
+            identity = OAuthIdentity.query.filter(
+                OAuthIdentity.token['refresh_token'] == refresh_token).one()
         # update old token
+        logger.debug("Updating the token to access the user's identity...")
         identity.token = token
+        logger.debug("Save the user's identity...")
         identity.save()
 
 

--- a/lifemonitor/auth/oauth2/client/providers/seek.py
+++ b/lifemonitor/auth/oauth2/client/providers/seek.py
@@ -75,8 +75,6 @@ class Seek(OAuth2IdentityProvider):
         return params
 
     def get_user_info(self, provider_user_id, token, normalized=True):
-        from lifemonitor.auth.oauth2.server.models import Token
-        logger.debug(f"{token} -- {Token.check_token_expiration(token['expires_at'])}")
         response = requests.get(urljoin(self.api_base_url,
                                         f'/people/{provider_user_id}?format=json'),
                                 headers={'Authorization': f'Bearer {token["access_token"]}'})

--- a/lifemonitor/auth/serializers.py
+++ b/lifemonitor/auth/serializers.py
@@ -71,14 +71,15 @@ class UserSchema(ResourceMetadataSchema):
     identities = fields.Method("get_identities")
 
     def get_identities(self, user):
-        identities = {}
-        for k, v in user.current_identity.items():
-            try:
-                identities[k] = IdentitySchema().dump(v)
-            except Exception as e:
-                logger.error("Unable to retrieve profile"
-                             "of user % r from provider % r: % r", user.id, k, str(e))
-                return {}
+        identities = None
+        if user.current_identity:
+            identities = {}
+            for k, v in user.current_identity.items():
+                try:
+                    identities[k] = IdentitySchema().dump(v)
+                except Exception as e:
+                    logger.error("Unable to retrieve profile"
+                                 "of user % r from provider % r: % r", user.id, k, str(e))
         return identities
 
 

--- a/lifemonitor/auth/serializers.py
+++ b/lifemonitor/auth/serializers.py
@@ -20,10 +20,16 @@
 
 from __future__ import annotations
 
-from lifemonitor.serializers import BaseSchema, ResourceMetadataSchema, ListOfItems, ma
+import logging
+
+from lifemonitor.serializers import (BaseSchema, ListOfItems,
+                                     ResourceMetadataSchema, ma)
 from marshmallow import fields
 
 from . import models
+
+# Config a module level logger
+logger = logging.getLogger(__name__)
 
 
 class ProviderSchema(BaseSchema):
@@ -59,10 +65,21 @@ class UserSchema(ResourceMetadataSchema):
 
     id = ma.auto_field()
     username = ma.auto_field()
-    # Uncomment to include all identities
-    identities = fields.Dict(attribute="current_identity",
-                             keys=fields.String(),
-                             values=fields.Nested(IdentitySchema()))
+    # identities = fields.Dict(attribute="current_identity",
+    #                          keys=fields.String(),
+    #                          values=fields.Nested(IdentitySchema()))
+    identities = fields.Method("get_identities")
+
+    def get_identities(self, user):
+        identities = {}
+        for k, v in user.current_identity.items():
+            try:
+                identities[k] = IdentitySchema().dump(v)
+            except Exception as e:
+                logger.error("Unable to retrieve profile"
+                             "of user % r from provider % r: % r", user.id, k, str(e))
+                return {}
+        return identities
 
 
 class ListOfUsers(ListOfItems):

--- a/lifemonitor/commands/oauth.py
+++ b/lifemonitor/commands/oauth.py
@@ -56,7 +56,7 @@ def token_invalidate(username):
     logger.debug("User found: %r", user)
     count = 0
     for identity in user.oauth_identity.values():
-        identity.set_token(invalidate_token(identity.token))
+        identity.token = invalidate_token(identity.token)
         identity.save()
         print("Token invalidated: %r !" % identity.token)
         count += 1

--- a/lifemonitor/config.py
+++ b/lifemonitor/config.py
@@ -66,6 +66,8 @@ class BaseConfig:
     # Enable refresh token generation.
     # Refresh tokens will be issued as part of authorization code flow tokens
     OAUTH2_REFRESH_TOKEN_GENERATOR = True
+    # Refresh the token <N> seconds before its expiration
+    OAUTH2_REFRESH_TOKEN_BEFORE_EXPIRATION = 5 * 60
     # JWT Settings
     JWT_SECRET_KEY_PATH = os.getenv("JWT_SECRET_KEY_PATH", 'certs/jwt-key')
     JWT_EXPIRATION_TIME = os.getenv("JWT_EXPIRATION_TIME", 3600)

--- a/lifemonitor/models.py
+++ b/lifemonitor/models.py
@@ -29,6 +29,9 @@ from sqlalchemy import types
 
 class ModelMixin(object):
 
+    def refresh(self, **kwargs):
+        db.session.refresh(self, **kwargs)
+
     def save(self):
         db.session.add(self)
         db.session.commit()

--- a/tests/config/registries/seek/doorkeeper.rb
+++ b/tests/config/registries/seek/doorkeeper.rb
@@ -1,0 +1,404 @@
+# frozen_string_literal: true
+
+Doorkeeper.configure do
+  # Change the ORM that doorkeeper will use (requires ORM extensions installed).
+  # Check the list of supported ORMs here: https://github.com/doorkeeper-gem/doorkeeper#orms
+  orm :active_record
+
+  # This block will be called to check whether the resource owner is authenticated or not.
+  resource_owner_authenticator do
+    if current_user
+      current_user
+    else
+      session[:return_to] = request.fullpath # This will be the authorization path i.e. /oauth/authorize?client_id=...
+                                             # The user will be redirected here after successfully authenticating.
+      redirect_to(login_path)
+      nil
+    end
+
+  end
+
+  # If you didn't skip applications controller from Doorkeeper routes in your application routes.rb
+  # file then you need to declare this block in order to restrict access to the web interface for
+  # adding oauth authorized applications. In other case it will return 403 Forbidden response
+  # every time somebody will try to access the admin web interface.
+  #
+   admin_authenticator do
+     current_user
+   end
+
+  # If you are planning to use Doorkeeper in Rails 5 API-only application, then you might
+  # want to use API mode that will skip all the views management and change the way how
+  # Doorkeeper responds to a requests.
+  #
+  # api_only
+
+  # Enforce token request content type to application/x-www-form-urlencoded.
+  # It is not enabled by default to not break prior versions of the gem.
+  #
+  # enforce_content_type
+
+  # Authorization Code expiration time (default: 10 minutes).
+  #
+  # authorization_code_expires_in 10.minutes
+
+  # Access token expiration time (default: 2 hours).
+  # If you want to disable expiration, set this to `nil`.
+  #
+  # access_token_expires_in 2.hours
+
+  # Assign custom TTL for access tokens. Will be used instead of access_token_expires_in
+  # option if defined. In case the block returns `nil` value Doorkeeper fallbacks to
+  # +access_token_expires_in+ configuration option value. If you really need to issue a
+  # non-expiring access token (which is not recommended) then you need to return
+  # Float::INFINITY from this block.
+  #
+  # `context` has the following properties available:
+  #
+  # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #
+  # custom_access_token_expires_in do |context|
+  #   context.client.application.additional_settings.implicit_oauth_expiration
+  # end
+
+  # Use a custom class for generating the access token.
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-access-token-generator
+  #
+  # access_token_generator '::Doorkeeper::JWT'
+
+  # The controller +Doorkeeper::ApplicationController+ inherits from.
+  # Defaults to +ActionController::Base+ unless +api_only+ is set, which changes the default to
+  # +ActionController::API+. The return value of this option must be a stringified class name.
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-base-controller
+  #
+  base_controller 'ApplicationController'
+
+  # Reuse access token for the same resource owner within an application (disabled by default).
+  #
+  # This option protects your application from creating new tokens before old valid one becomes
+  # expired so your database doesn't bloat. Keep in mind that when this option is `on` Doorkeeper
+  # doesn't updates existing token expiration time, it will create a new token instead.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
+  #
+  # You can not enable this option together with +hash_token_secrets+.
+  #
+  # reuse_access_token
+
+  # Set a limit for token_reuse if using reuse_access_token option
+  #
+  # This option limits token_reusability to some extent.
+  # If not set then access_token will be reused unless it expires.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1189
+  #
+  # This option should be a percentage(i.e. (0,100])
+  #
+  # token_reuse_limit 100
+
+  # Hash access and refresh tokens before persisting them.
+  # This will disable the possibility to use +reuse_access_token+
+  # since plain values can no longer be retrieved.
+  #
+  # Note: If you are already a user of doorkeeper and have existing tokens
+  # in your installation, they will be invalid without enabling the additional
+  # setting `fallback_to_plain_secrets` below.
+  #
+  # hash_token_secrets
+  # By default, token secrets will be hashed using the
+  # +Doorkeeper::Hashing::SHA256+ strategy.
+  #
+  # If you wish to use another hashing implementation, you can override
+  # this strategy as follows:
+  #
+  # hash_token_secrets using: '::Doorkeeper::Hashing::MyCustomHashImpl'
+  #
+  # Keep in mind that changing the hashing function will invalidate all existing
+  # secrets, if there are any.
+
+  # Hash application secrets before persisting them.
+  #
+  # hash_application_secrets
+  #
+  # By default, applications will be hashed
+  # with the +Doorkeeper::SecretStoring::SHA256+ strategy.
+  #
+  # If you wish to use bcrypt for application secret hashing, uncomment
+  # this line instead:
+  #
+  # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt'
+
+  # When the above option is enabled, and a hashed token or secret is not found,
+  # you can allow to fall back to another strategy. For users upgrading
+  # doorkeeper and wishing to enable hashing, you will probably want to enable
+  # the fallback to plain tokens.
+  #
+  # This will ensure that old access tokens and secrets
+  # will remain valid even if the hashing above is enabled.
+  #
+  # fallback_to_plain_secrets
+
+  # Issue access tokens with refresh token (disabled by default), you may also
+  # pass a block which accepts `context` to customize when to give a refresh
+  # token or not. Similar to +custom_access_token_expires_in+, `context` has
+  # the following properties:
+  #
+  # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #
+  use_refresh_token
+
+  # Provide support for an owner to be assigned to each registered application (disabled by default)
+  # Optional parameter confirmation: true (default: false) if you want to enforce ownership of
+  # a registered application
+  # NOTE: you must also run the rails g doorkeeper:application_owner generator
+  # to provide the necessary support
+  #
+  enable_application_owner confirmation: false
+
+  # Define access token scopes for your provider
+  # For more information go to
+  # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
+  #
+  default_scopes  :read
+  optional_scopes :write
+
+  # Allows to restrict only certain scopes for grant_type.
+  # By default, all the scopes will be available for all the grant types.
+  #
+  # Keys to this hash should be the name of grant_type and
+  # values should be the array of scopes for that grant type.
+  # Note: scopes should be from configured_scopes (i.e. default or optional)
+  #
+  # scopes_by_grant_type password: [:write], client_credentials: [:update]
+
+  # Forbids creating/updating applications with arbitrary scopes that are
+  # not in configuration, i.e. +default_scopes+ or +optional_scopes+.
+  # (disabled by default)
+  #
+  # enforce_configured_scopes
+
+  # Change the way client credentials are retrieved from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
+  #
+  # client_credentials :from_basic, :from_params
+
+  # Change the way access token is authenticated from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
+  #
+  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+  # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
+  # by default in non-development environments). OAuth2 delegates security in
+  # communication to the HTTPS protocol so it is wise to keep this enabled.
+  #
+  # Callable objects such as proc, lambda, block or any object that responds to
+  # #call can be used in order to allow conditional checks (to allow non-SSL
+  # redirects to localhost for example).
+  #
+  # force_ssl_in_redirect_uri !Rails.env.development?
+  #
+  # force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
+
+  # Specify what redirect URI's you want to block during Application creation.
+  # Any redirect URI is whitelisted by default.
+  #
+  # You can use this option in order to forbid URI's with 'javascript' scheme
+  # for example.
+  #
+  # forbid_redirect_uri { |uri| uri.scheme.to_s.downcase == 'javascript' }
+
+  # Allows to set blank redirect URIs for Applications in case Doorkeeper configured
+  # to use URI-less OAuth grant flows like Client Credentials or Resource Owner
+  # Password Credentials. The option is on by default and checks configured grant
+  # types, but you **need** to manually drop `NOT NULL` constraint from `redirect_uri`
+  # column for `oauth_applications` database table.
+  #
+  # You can completely disable this feature with:
+  #
+  # allow_blank_redirect_uri false
+  #
+  # Or you can define your custom check:
+  #
+  # allow_blank_redirect_uri do |grant_flows, client|
+  #   client.superapp?
+  # end
+
+  # Specify how authorization errors should be handled.
+  # By default, doorkeeper renders json errors when access token
+  # is invalid, expired, revoked or has invalid scopes.
+  #
+  # If you want to render error response yourself (i.e. rescue exceptions),
+  # set +handle_auth_errors+ to `:raise` and rescue Doorkeeper::Errors::InvalidToken
+  # or following specific errors:
+  #
+  #   Doorkeeper::Errors::TokenForbidden, Doorkeeper::Errors::TokenExpired,
+  #   Doorkeeper::Errors::TokenRevoked, Doorkeeper::Errors::TokenUnknown
+  #
+  # handle_auth_errors :raise
+
+  # Customize token introspection response.
+  # Allows to add your own fields to default one that are required by the OAuth spec
+  # for the introspection response. It could be `sub`, `aud` and so on.
+  # This configuration option can be a proc, lambda or any Ruby object responds
+  # to `.call` method and result of it's invocation must be a Hash.
+  #
+  # custom_introspection_response do |token, context|
+  #   {
+  #     "sub": "Z5O3upPC88QrAjx00dis",
+  #     "aud": "https://protected.example.net/resource",
+  #     "username": User.find(token.resource_owner_id).username
+  #   }
+  # end
+  #
+  # or
+  #
+  # custom_introspection_response CustomIntrospectionResponder
+
+  # Specify what grant flows are enabled in array of Strings. The valid
+  # strings and the flows they enable are:
+  #
+  # "authorization_code" => Authorization Code Grant Flow
+  # "implicit"           => Implicit Grant Flow
+  # "password"           => Resource Owner Password Credentials Grant Flow
+  # "client_credentials" => Client Credentials Grant Flow
+  #
+  # If not specified, Doorkeeper enables authorization_code and
+  # client_credentials.
+  #
+  # implicit and password grant flows have risks that you should understand
+  # before enabling:
+  #   http://tools.ietf.org/html/rfc6819#section-4.4.2
+  #   http://tools.ietf.org/html/rfc6819#section-4.4.3
+  #
+  grant_flows %w[authorization_code]
+
+  # Allows to customize OAuth grant flows that +each+ application support.
+  # You can configure a custom block (or use a class respond to `#call`) that must
+  # return `true` in case Application instance supports requested OAuth grant flow
+  # during the authorization request to the server. This configuration +doesn't+
+  # set flows per application, it only allows to check if application supports
+  # specific grant flow.
+  #
+  # For example you can add an additional database column to `oauth_applications` table,
+  # say `t.array :grant_flows, default: []`, and store allowed grant flows that can
+  # be used with this application there. Then when authorization requested Doorkeeper
+  # will call this block to check if specific Application (passed with client_id and/or
+  # client_secret) is allowed to perform the request for the specific grant type
+  # (authorization, password, client_credentials, etc).
+  #
+  # Example of the block:
+  #
+  #   ->(flow, client) { client.grant_flows.include?(flow) }
+  #
+  # In case this option invocation result is `false`, Doorkeeper server returns
+  # :unauthorized_client error and stops the request.
+  #
+  # @param allow_grant_flow_for_client [Proc] Block or any object respond to #call
+  # @return [Boolean] `true` if allow or `false` if forbid the request
+  #
+  # allow_grant_flow_for_client do |grant_flow, client|
+  #   # `grant_flows` is an Array column with grant
+  #   # flows that application supports
+  #
+  #   client.grant_flows.include?(grant_flow)
+  # end
+
+  # Hook into the strategies' request & response life-cycle in case your
+  # application needs advanced customization or logging:
+  #
+  # before_successful_strategy_response do |request|
+  #   puts "BEFORE HOOK FIRED! #{request}"
+  # end
+  #
+  # after_successful_strategy_response do |request, response|
+  #   puts "AFTER HOOK FIRED! #{request}, #{response}"
+  # end
+
+  # Hook into Authorization flow in order to implement Single Sign Out
+  # or add any other functionality.
+  #
+  # before_successful_authorization do |controller|
+  #   Rails.logger.info(controller.request.params.inspect)
+  # end
+  #
+  # after_successful_authorization do |controller|
+  #   controller.session[:logout_urls] <<
+  #     Doorkeeper::Application
+  #       .find_by(controller.request.params.slice(:redirect_uri))
+  #       .logout_uri
+  # end
+
+  # Under some circumstances you might want to have applications auto-approved,
+  # so that the user skips the authorization step.
+  # For example if dealing with a trusted application.
+  #
+  # skip_authorization do |resource_owner, client|
+  #   client.superapp? or resource_owner.admin?
+  # end
+
+  # Configure custom constraints for the Token Introspection request.
+  # By default this configuration option allows to introspect a token by another
+  # token of the same application, OR to introspect the token that belongs to
+  # authorized client (from authenticated client) OR when token doesn't
+  # belong to any client (public token). Otherwise requester has no access to the
+  # introspection and it will return response as stated in the RFC.
+  #
+  # Block arguments:
+  #
+  # @param token [Doorkeeper::AccessToken]
+  #   token to be introspected
+  #
+  # @param authorized_client [Doorkeeper::Application]
+  #   authorized client (if request is authorized using Basic auth with
+  #   Client Credentials for example)
+  #
+  # @param authorized_token [Doorkeeper::AccessToken]
+  #   Bearer token used to authorize the request
+  #
+  # In case the block returns `nil` or `false` introspection responses with 401 status code
+  # when using authorized token to introspect, or you'll get 200 with { "active": false } body
+  # when using authorized client to introspect as stated in the
+  # RFC 7662 section 2.2. Introspection Response.
+  #
+  # Using with caution:
+  # Keep in mind that these three parameters pass to block can be nil as following case:
+  #  `authorized_client` is nil if and only if `authorized_token` is present, and vice versa.
+  #  `token` will be nil if and only if `authorized_token` is present.
+  # So remember to use `&` or check if it is present before calling method on
+  # them to make sure you doesn't get NoMethodError exception.
+  #
+  # You can define your custom check:
+  #
+  # allow_token_introspection do |token, authorized_client, authorized_token|
+  #   if authorized_token
+  #     # customize: require `introspection` scope
+  #     authorized_token.application == token&.application ||
+  #       authorized_token.scopes.include?("introspection")
+  #   elsif token.application
+  #     # `protected_resource` is a new database boolean column, for example
+  #     authorized_client == token.application || authorized_client.protected_resource?
+  #   else
+  #     # public token (when token.application is nil, token doesn't belong to any application)
+  #     true
+  #   end
+  # end
+  #
+  # Or you can completely disable any token introspection:
+  #
+  # allow_token_introspection false
+  #
+  # If you need to block the request at all, then configure your routes.rb or web-server
+  # like nginx to forbid the request.
+
+  # WWW-Authenticate Realm (default: "Doorkeeper").
+  #
+  # realm "Doorkeeper"
+end

--- a/tests/unit/auth/models/test_tokens.py
+++ b/tests/unit/auth/models/test_tokens.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2020-2021 CRS4
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import logging
+from unittest.mock import PropertyMock, patch
+
+import pytest
+from lifemonitor.auth.oauth2.client.models import OAuth2Token
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger()
+
+
+@pytest.fixture
+def user_identity(app_client, user1, provider_type):
+    logger.debug(user1.keys())
+    logger.debug(user1['user_info'].keys())
+    user = user1['user']
+    logger.debug(user)
+    logger.debug(provider_type.value)
+    identity = user.oauth_identity[provider_type.value]
+    assert identity, f"Unable to find user identity on provider {provider_type.value}"
+    logger.debug(identity)
+    return identity
+
+
+@patch("lifemonitor.auth.oauth2.client.models.OAuthIdentity.fetch_token")
+def test_fetch_token_call_on_user_info(fetch_token_method, user_identity):
+    logger.debug(user_identity)
+    # reset user_info on the current identity instance
+    user_identity._user_info = None
+    user_info = user_identity.user_info
+    logger.debug("user_info: %r", user_info)
+    assert user_info, "Unable to get user info"
+    fetch_token_method.assert_called_once()
+
+
+@patch("lifemonitor.auth.oauth2.client.models.OAuthIdentity.fetch_token")
+def test_fetch_token_call_on_as_http_header(fetch_token_method, user_identity):
+    logger.debug(user_identity)
+    # reset user_info on the current identity instance
+    user_identity._user_info = None
+    header = user_identity.as_http_header()
+    logger.debug("as header: %r", header)
+    assert header, "Unable to convert identity to HTTP header"
+    fetch_token_method.assert_called_once()
+
+
+@patch("lifemonitor.auth.oauth2.client.models.OAuth2Token.to_be_refreshed")
+def test_fetch_token_on_token_not_expired(check_token, user_identity):
+    logger.debug(user_identity)
+    current_token = user_identity.token
+    logger.debug("Current token: %r", current_token)
+    check_token.return_value = False
+    fetched_token = user_identity.fetch_token()
+    logger.debug("Fetched token: %r", fetched_token)
+    check_token.assert_called_once()
+    assert fetched_token == current_token, "DB and fetched tokens should be equal"
+
+
+@patch("lifemonitor.auth.oauth2.client.models.OAuth2Token.to_be_refreshed")
+def test_fetch_token_on_token_expired(check_token, user_identity):
+    logger.debug(user_identity)
+    current_token = user_identity.token
+    logger.debug("Current token: %r", current_token)
+    check_token.return_value = True
+    fetched_token = user_identity.fetch_token()
+    logger.debug("Fetched token: %r", fetched_token)
+    check_token.assert_called_once()
+    assert fetched_token != current_token, "DB and fetched tokens should not be equal"
+    assert fetched_token['created_at'] > current_token['created_at'], \
+        "Refreshed token should be more recent"
+
+
+@patch("lifemonitor.auth.oauth2.client.models.OAuthIdentity.token", new_callable=PropertyMock)
+def test_fetch_token_on_not_refreshable_token_expired(token_property, user_identity):
+    logger.debug(user_identity)
+    # remove the refresh token from the current token
+    token = user_identity._token
+    token['expires_at'] = token['created_at']
+    del token['refresh_token']
+    token = OAuth2Token(token)
+    token_property.return_value = token
+    current_token = user_identity.token
+    logger.debug("Current token: %r -- to be refreshed: %r", current_token, current_token.to_be_refreshed())
+    fetched_token = user_identity.fetch_token()
+    logger.debug("Fetched token: %r", fetched_token)
+    assert fetched_token == current_token, "DB and fetched tokens should be equal"

--- a/tests/unit/auth/models/test_tokens.py
+++ b/tests/unit/auth/models/test_tokens.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 
 import logging
+import time
 from unittest.mock import PropertyMock, patch
 
 import pytest
@@ -81,6 +82,7 @@ def test_fetch_token_on_token_expired(check_token, user_identity):
     current_token = user_identity.token
     logger.debug("Current token: %r", current_token)
     check_token.return_value = True
+    time.sleep(1)
     fetched_token = user_identity.fetch_token()
     logger.debug("Fetched token: %r", fetched_token)
     check_token.assert_called_once()

--- a/tests/unit/auth/services/test_authorized.py
+++ b/tests/unit/auth/services/test_authorized.py
@@ -18,12 +18,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import pytest
 import logging
-from tests import utils
+
+import pytest
+from lifemonitor.auth import models, services
 from lifemonitor.lang import messages
-from lifemonitor.auth import models
-from lifemonitor.auth import services
+from tests import utils
 
 logger = logging.getLogger()
 

--- a/tests/unit/auth/services/test_authorized.py
+++ b/tests/unit/auth/services/test_authorized.py
@@ -24,8 +24,6 @@ from tests import utils
 from lifemonitor.lang import messages
 from lifemonitor.auth import models
 from lifemonitor.auth import services
-from werkzeug.wrappers import Response
-from tests import conftest_helpers as helpers
 
 logger = logging.getLogger()
 
@@ -54,39 +52,3 @@ def test_unauthorized_user_without_identity(app_client,
         authorized_func()
     utils.assert_error_message(
         messages.unauthorized_user_without_registry_identity.format(registry.name), e)
-
-
-def test_unauthorized_user_with_expired_registry_token(app_client, user1, authorized_func,
-                                                       client_credentials_registry):
-    helpers.enable_auto_login(user1['user'])
-    user = user1['user']
-    logger.debug(f"The user: {user}")
-    services.login_user(user)
-    registry = client_credentials_registry
-    services.login_registry(registry)
-    assert registry.name in user.oauth_identity, "Missing user identity"
-    identity = user.oauth_identity[registry.name]
-    # extract the identity token
-    token = identity.token
-    # ensure the token doesn't have a refresh token
-    token.pop('refresh_token', False)
-    # make the token expired
-    token['expires_at'] = token['created_at']
-    user_info = identity.user_info
-    logger.debug(user_info)
-    # calling the decorator with such a token
-    # will result in a redirection
-    response = authorized_func()
-    logger.debug(response)
-    assert isinstance(response, Response)
-    assert response.status_code == 307, "Unexpected status code"
-    # the redirection to the original endpoint is marked with param 'redirection'
-    # and if the token is still expired an error will be reported
-    with app_client.application.test_request_context('/?redirection=true'):
-        services.login_user(user)
-        services.login_registry(registry)
-        with pytest.raises(services.NotAuthorizedException) as e:
-            authorized_func()
-        utils.assert_error_message(
-            messages.unauthorized_user_with_expired_registry_token.format(
-                registry.name, registry.name), e)


### PR DESCRIPTION
This PR allows LifeMonitor to transparently refresh tokens used to interact with third-party services, like identity providers and registries. 
If a third-party service supports refresh tokens, the access token for that service will be automatically refreshed:
1. if a user logs in to LifeMonitor using the service as identity provider;
2. if LifeMonitor needs to interact with the service and the corresponding access token is expired or close to expiring.