### PR TITLE
Fix handling of test definition from ro-crates

### DIFF
--- a/lifemonitor/test_metadata.py
+++ b/lifemonitor/test_metadata.py
@@ -234,14 +234,13 @@ def get_roc_suites(crate):
                 })
         definition = suite.definition
         if definition:
-            path = Path(definition.id).relative_to(crate.test_dir.id)
             t = _TO_OLD_TYPES.get(definition.conformsTo.id, "unknown")
             suite_data["definition"] = {
                 "test_engine": {
                     "type": t,
                     "version": definition.engineVersion,
                 },
-                "path": str(path),
+                "path": definition.id,
             }
         else:
             suite_data["definition"] = {}


### PR DESCRIPTION
There is no special "test" dir in the current testing crate spec, and testing material could be anywhere in the crate. I forgot to address this in #79.