### PR TITLE
Override static width settings

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -10,3 +10,19 @@ text move.
 a:hover, a:focus {
     font-weight: normal;
 }
+
+/*
+Override static width settings.
+*/
+.wrapper {
+  width: 100%;
+}
+
+section {
+  width: 70%;
+}
+
+header {
+  width: 30%;
+  max-width: 270px;
+}


### PR DESCRIPTION
This PR overrides the template's static column widths so that the layout of the page can use the full width of the browser