### PR TITLE
Fix call to show_current_user_profile with local users

### DIFF
--- a/tests/unit/auth/models/test_users.py
+++ b/tests/unit/auth/models/test_users.py
@@ -55,5 +55,6 @@ def test_identity_unavailable(app_client, user1):
     assert user.current_identity is None, "Identity should be empty"
     serialization = serializers.UserSchema().dump(user)
     logger.debug(serialization)
-    assert serialization['identities'] is None, \
-        "The 'identity' property should be empty on the serialized user"
+    assert "lifemonitor" in serialization['identities']
+    lm_identity = serialization['identities']["lifemonitor"]
+    assert lm_identity["provider"]["name"] == "LifeMonitor"


### PR DESCRIPTION
The fix was implemented at the serialization layer, returning a
spec-compliant LifeMonitor identity.