### PR TITLE
Accept a workflow without an id 

### DIFF
--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -1351,7 +1351,6 @@ components:
               example: 123e4567-e89b-12d3-a456-426614174000
           required:
             - roc_link
-            - version
         - $ref: "#/components/schemas/WorkflowVersionBase"
 
     RegistryWorkflowVersion:

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -1350,7 +1350,6 @@ components:
                 Universal unique identifier of the workflow.
               example: 123e4567-e89b-12d3-a456-426614174000
           required:
-            - uuid
             - roc_link
             - version
         - $ref: "#/components/schemas/WorkflowVersionBase"

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -1404,7 +1404,7 @@ components:
               type: boolean
               readOnly: true
               description: |
-                `true` if the workflow version is the latest, 
+                `true` if the workflow version is the latest,
                 `false` otherwise.
               example: true
             submitter:

--- a/tests/integration/api/controllers/test_users.py
+++ b/tests/integration/api/controllers/test_users.py
@@ -133,6 +133,32 @@ def test_generic_workflow_registration(app_client, client_auth_method,
     ClientAuthenticationMethod.API_KEY,
     ClientAuthenticationMethod.AUTHORIZATION_CODE,
 ], indirect=True)
+def test_generic_workflow_registration_wo_uuid(app_client, client_auth_method,
+                                               user1, user1_auth, client_credentials_registry, generic_workflow):
+    logger.debug("User: %r", user1)
+    logger.debug("headers: %r", user1_auth)
+    workflow = generic_workflow
+    logger.debug("Selected workflow: %r", workflow)
+    logger.debug("Using oauth2 user: %r", user1)
+    # prepare body
+    body = {'roc_link': workflow['roc_link'],
+            'version': workflow['version'],
+            'authorization': workflow['authorization']}
+    logger.debug("The BODY: %r", body)
+    response = app_client.post('/users/current/workflows', json=body, headers=user1_auth)
+    logger.debug("The actual response: %r", response.data)
+    utils.assert_status_code(201, response.status_code)
+    data = json.loads(response.data)
+    logger.debug("Response data: %r", data)
+    assert data['wf_version'] == workflow['version'], \
+        "Response should be equal to the workflow UUID"
+    assert data['wf_uuid'], "Workflow UUID was not generated or returned"
+
+
+@pytest.mark.parametrize("client_auth_method", [
+    ClientAuthenticationMethod.API_KEY,
+    ClientAuthenticationMethod.AUTHORIZATION_CODE,
+], indirect=True)
 def test_registry_workflow_registration(app_client, client_auth_method,
                                         user1, user1_auth, client_credentials_registry, valid_workflow):
     logger.debug("User: %r", user1)

--- a/tests/integration/api/controllers/test_workflows.py
+++ b/tests/integration/api/controllers/test_workflows.py
@@ -218,7 +218,7 @@ def test_get_workflow_latest_version(app_client, client_auth_method, user1, user
     utils.register_workflow(user1, wv2)
 
     response = app_client.get(utils.build_workflow_path(), headers=user1_auth)
-    utils.assert_status_code(response.status_code, 200)
+    utils.assert_status_code(200, response.status_code)
     workflows = json.loads(response.data)
     logger.debug("Workflows: %r", workflows)
 
@@ -226,7 +226,7 @@ def test_get_workflow_latest_version(app_client, client_auth_method, user1, user
     logger.debug("URL: %r", url)
     response = app_client.get(url, headers=user1_auth)
     logger.debug(response)
-    utils.assert_status_code(response.status_code, 200)
+    utils.assert_status_code(200, response.status_code)
     data = json.loads(response.data)
     logger.debug("Response data: %r", data)
     assert data['uuid'] == workflow['uuid'], "Unexpected workflow ID"
@@ -256,7 +256,7 @@ def test_get_workflow_versions(app_client, client_auth_method, user1, user1_auth
     logger.debug("URL: %r", url)
     response = app_client.get(url, headers=user1_auth)
     logger.debug(response)
-    utils.assert_status_code(response.status_code, 200)
+    utils.assert_status_code(200, response.status_code)
     data = json.loads(response.data)
     logger.debug("Response data: %r", data)
 
@@ -279,7 +279,7 @@ def test_get_workflow_status(app_client, client_auth_method, user1, user1_auth, 
     w, workflow = utils.pick_and_register_workflow(user1, valid_workflow)
     response = app_client.get(f"{utils.build_workflow_path(w, subpath='status')}", headers=user1_auth)
     logger.debug(response)
-    utils.assert_status_code(response.status_code, 200)
+    utils.assert_status_code(200, response.status_code)
     data = json.loads(response.data)
     logger.debug("Response data: %r", data)
     assert data['uuid'] == w['uuid'], "Unexpected workflow ID"
@@ -299,7 +299,7 @@ def test_get_workflow_suites(app_client, client_auth_method, user1, user1_auth, 
     w, workflow = utils.pick_and_register_workflow(user1, valid_workflow)
     response = app_client.get(f"{utils.build_workflow_path(w, subpath='suites')}", headers=user1_auth)
     logger.debug(response)
-    utils.assert_status_code(response.status_code, 200)
+    utils.assert_status_code(200, response.status_code)
     data = json.loads(response.data)
     logger.debug("Response data: %r", data)
     assert "items" in data, "Missing items property"

--- a/tests/unit/api/controllers/test_suites.py
+++ b/tests/unit/api/controllers/test_suites.py
@@ -46,7 +46,7 @@ def test_get_suite_error_not_found(m, request_context, mock_user):
     m.get_suite.return_value = None
     response = controllers.suites_get_by_uuid("123456")
     m.get_suite.assert_called_once()
-    assert_status_code(response.status_code, 404), "Unexpected status code"
+    assert_status_code(404, response.status_code), "Unexpected status code"
 
 
 @patch("lifemonitor.api.controllers.lm")

--- a/tests/unit/api/controllers/test_workflows.py
+++ b/tests/unit/api/controllers/test_workflows.py
@@ -125,7 +125,7 @@ def test_post_workflow_by_user_error_missing_input_data(m, request_context, mock
     m.get_workflow_registry_by_generic_reference.assert_called_once_with(data["registry"]), \
         "get_workflow_registry_by_uri should be used"
     logger.debug("Response: %r, %r", response, str(response.data))
-    assert_status_code(response.status_code, 400)
+    assert_status_code(400, response.status_code)
 
 
 @patch("lifemonitor.api.controllers.lm")
@@ -150,7 +150,7 @@ def test_post_workflow_by_user(m, request_context, mock_user):
     response = controllers.workflows_post(body=data)
     m.get_workflow_registry_by_generic_reference.assert_called_once_with(data["registry"]), \
         "get_workflow_registry_by_uri should be used"
-    assert_status_code(response[1], 201)
+    assert_status_code(201, response[1])
     assert response[0]["wf_uuid"] == data['uuid'] and \
         response[0]["wf_version"] == data['version']
 
@@ -163,7 +163,7 @@ def test_post_workflow_by_registry_error_registry_uri(m, request_context, mock_r
     data = {"registry": "123456"}
     response = controllers.workflows_post(body=data)
     logger.debug("Response: %r, %r", response, str(response.data))
-    assert_status_code(response.status_code, 400)
+    assert_status_code(400, response.status_code)
     assert messages.unexpected_registry_uri in response.data.decode(),\
         "Unexpected error message"
 
@@ -177,7 +177,7 @@ def test_post_workflow_by_registry_error_submitter_not_found(m, request_context,
     m.find_registry_user_identity.side_effect = OAuthIdentityNotFoundException()
     response = controllers.workflows_post(body=data)
     logger.debug("Response: %r, %r", response, str(response.data))
-    assert_status_code(response.status_code, 401)
+    assert_status_code(401, response.status_code)
     assert messages.no_user_oauth_identity_on_registry \
         .format(data["submitter_id"], mock_registry.name) in response.data.decode(),\
         "Unexpected error message"
@@ -202,7 +202,7 @@ def test_post_workflow_by_registry(m, request_context, mock_registry):
     m.register_workflow.return_value = w
     response = controllers.workflows_post(body=data)
     logger.debug("Response: %r", response)
-    assert_status_code(response[1], 201)
+    assert_status_code(201, response[1])
     assert response[0]["wf_uuid"] == data['uuid'] and \
         response[0]["wf_version"] == data['version']
 
@@ -224,7 +224,7 @@ def test_post_workflow_by_registry_invalid_rocrate(m, request_context, mock_regi
     m.register_workflow.side_effect = lm_exceptions.NotValidROCrateException()
     response = controllers.workflows_post(body=data)
     logger.debug("Response: %r", response)
-    assert_status_code(response.status_code, 400)
+    assert_status_code(400, response.status_code)
     assert messages.invalid_ro_crate in response.data.decode()
 
 
@@ -245,7 +245,7 @@ def test_post_workflow_by_registry_not_authorized(m, request_context, mock_regis
     m.register_workflow.side_effect = lm_exceptions.NotAuthorizedException()
     response = controllers.workflows_post(body=data)
     logger.debug("Response: %r", response)
-    assert_status_code(response.status_code, 403)
+    assert_status_code(403, response.status_code)
     assert messages.not_authorized_registry_access\
         .format(mock_registry.name) in response.data.decode()
 
@@ -257,14 +257,14 @@ def test_get_workflow_by_id_error_not_found(m, request_context, mock_registry):
     m.get_registry_workflow_version.side_effect = lm_exceptions.EntityNotFoundException(models.WorkflowVersion)
     response = controllers.workflows_get_by_id(wf_uuid="12345", wf_version="1")
     logger.debug("Response: %r", response)
-    assert_status_code(response.status_code, 404)
+    assert_status_code(404, response.status_code)
     assert messages.workflow_not_found\
         .format("12345", "1") in response.data.decode()
     # test when the service return None
     m.get_registry_workflow_version.return_value = None
     response = controllers.workflows_get_by_id(wf_uuid="12345", wf_version="1")
     logger.debug("Response: %r", response)
-    assert_status_code(response.status_code, 404)
+    assert_status_code(404, response.status_code)
     assert messages.workflow_not_found\
         .format("12345", "1") in response.data.decode()
 

--- a/tests/unit/api/controllers/test_workflows.py
+++ b/tests/unit/api/controllers/test_workflows.py
@@ -21,12 +21,13 @@
 import logging
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import lifemonitor.api.controllers as controllers
 import lifemonitor.api.models as models
 import lifemonitor.api.serializers as serializers
 import lifemonitor.auth as auth
 import lifemonitor.exceptions as lm_exceptions
-import pytest
 from lifemonitor.auth.oauth2.client.models import \
     OAuthIdentityNotFoundException
 from lifemonitor.lang import messages

--- a/tests/unit/api/controllers/test_workflows.py
+++ b/tests/unit/api/controllers/test_workflows.py
@@ -172,7 +172,7 @@ def test_post_workflow_by_registry_error_submitter_not_found(m, request_context,
     assert auth.current_user.is_anonymous, "Unexpected user in session"
     assert auth.current_registry, "Unexpected registry in session"
     # add one fake workflow
-    data = {"submitter_id": 1}
+    data = {"submitter_id": 1, "identifier": 1}
     m.find_registry_user_identity.side_effect = OAuthIdentityNotFoundException()
     response = controllers.workflows_post(body=data)
     logger.debug("Response: %r, %r", response, str(response.data))


### PR DESCRIPTION
A user may register a workflow that is not registered elsewhere, and thus does not have a pre-assigned id.  With this PR, for such workflows LM will dynamically generate a UUID and return it to the caller.