### PR TITLE
Remove last_logs from build summaries

### DIFF
--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -160,7 +160,7 @@ def registry_user_workflows_get(user_id):
     try:
         identity = lm.find_registry_user_identity(current_registry, external_id=user_id)
         workflows = lm.get_user_registry_workflows(identity.user, current_registry)
-        logger.debug("workflows_get. Got %s workflows (user: %s)", len(workflows), current_user)
+        logger.debug("registry_user_workflows_get. Got %s workflows (user: %s)", len(workflows), current_user)
         workflow_status = request.args.get('status', 'true').lower() == 'true'
         return serializers.ListOfWorkflows(workflow_status=workflow_status).dump(workflows)
     except OAuthIdentityNotFoundException:
@@ -181,7 +181,7 @@ def user_workflows_get():
     if not current_user or current_user.is_anonymous:
         return lm_exceptions.report_problem(401, "Unauthorized", detail=messages.no_user_in_session)
     workflows = lm.get_user_workflows(current_user)
-    logger.debug("workflows_get. Got %s workflows (user: %s)", len(workflows), current_user)
+    logger.debug("user_workflows_get. Got %s workflows (user: %s)", len(workflows), current_user)
     workflow_status = request.args.get('status', 'true').lower() == 'true'
     return serializers.ListOfWorkflows(workflow_status=workflow_status).dump(workflows)
 

--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -324,11 +324,11 @@ def workflows_delete(wf_uuid, wf_version):
             return lm_exceptions.report_problem(403, "Forbidden",
                                                 detail=messages.no_user_in_session)
         return connexion.NoContent, 204
+    except OAuthIdentityNotFoundException as e:
+        return lm_exceptions.report_problem(401, "Unauthorized", extra_info={"exception": str(e)})
     except lm_exceptions.EntityNotFoundException as e:
         return lm_exceptions.report_problem(404, "Not Found", extra_info={"exception": str(e.detail)},
                                             detail=messages.workflow_not_found.format(wf_uuid, wf_version))
-    except OAuthIdentityNotFoundException as e:
-        return lm_exceptions.report_problem(401, "Unauthorized", extra_info={"exception": str(e)})
     except lm_exceptions.NotAuthorizedException as e:
         return lm_exceptions.report_problem(403, "Forbidden", extra_info={"exception": str(e)})
     except Exception as e:
@@ -491,11 +491,11 @@ def instances_delete_by_id(instance_uuid):
             return response
         lm.deregister_test_instance(response)
         return connexion.NoContent, 204
+    except OAuthIdentityNotFoundException as e:
+        return lm_exceptions.report_problem(401, "Unauthorized", extra_info={"exception": str(e)})
     except lm_exceptions.EntityNotFoundException as e:
         return lm_exceptions.report_problem(404, "Not Found", extra_info={"exception": str(e.detail)},
                                             detail=messages.instance_not_found.format(instance_uuid))
-    except OAuthIdentityNotFoundException as e:
-        return lm_exceptions.report_problem(401, "Unauthorized", extra_info={"exception": str(e)})
     except lm_exceptions.NotAuthorizedException as e:
         return lm_exceptions.report_problem(403, "Forbidden", extra_info={"exception": str(e)})
     except Exception as e:

--- a/lifemonitor/api/models/services/service.py
+++ b/lifemonitor/api/models/services/service.py
@@ -184,10 +184,12 @@ class TestingService(db.Model, ModelMixin):
         try:
             # return the service obj if the service has already been registered
             instance = cls.find_by_url(url)
-            logger.debug("Found service instance: %r", instance)
+            logger.debug("Service instance %r for URL %r found in DB", instance, url)
             if instance:
                 return instance
             # try to instanciate the service if the it has not been registered yet
+            logger.debug("No service for URL %r.  Registering a service of type %r now",
+                         url, service_type)
             return cls.service_type_registry.get_class(service_type)(url)
         except KeyError:
             raise lm_exceptions.TestingServiceNotSupportedException(f"Not supported testing service type '{service_type}'")

--- a/lifemonitor/api/serializers.py
+++ b/lifemonitor/api/serializers.py
@@ -217,10 +217,6 @@ class BuildSummarySchema(ResourceMetadataSchema):
     status = fields.String()
     instance = ma.Nested(TestInstanceSchema(exclude=('meta',)), attribute="test_instance")
     timestamp = fields.String()
-    last_logs = fields.Method("get_last_logs")
-
-    def get_last_logs(self, obj):
-        return obj.get_output(0, 131072)
 
 
 class WorkflowVersionListItem(WorkflowSchema):

--- a/lifemonitor/exceptions.py
+++ b/lifemonitor/exceptions.py
@@ -33,14 +33,16 @@ logger = logging.getLogger(__name__)
 class LifeMonitorException(Exception):
 
     def __init__(self, title=None, detail=None,
-                 type="about:blank", status=500, instance=None, **kwargs):
-        self.title = title
-        self.detail = detail
-        self.type = type
+            type="about:blank", status: int=500, instance=None, **kwargs):
+        self.title    = str(title)    if title    is not None else None
+        self.detail   = str(detail)   if detail   is not None else None
+        self.type     = str(type)     if type     is not None else None
+        self.instance = str(instance) if instance is not None else None
         self.status = status
-        self.instance = instance
         if len(kwargs) > 0:
-            self.extra_info = kwargs
+            self.extra_info = {
+                str(k): str(v) if v is not None else None
+                for k, v in kwargs.items() }
         if instance is None:
             try:
                 self.instance = request.url

--- a/lifemonitor/exceptions.py
+++ b/lifemonitor/exceptions.py
@@ -33,16 +33,16 @@ logger = logging.getLogger(__name__)
 class LifeMonitorException(Exception):
 
     def __init__(self, title=None, detail=None,
-            type="about:blank", status: int=500, instance=None, **kwargs):
-        self.title    = str(title)    if title    is not None else None
-        self.detail   = str(detail)   if detail   is not None else None
-        self.type     = str(type)     if type     is not None else None
+                 type="about:blank", status: int = 500, instance=None, **kwargs):
+        self.title = str(title) if title is not None else None
+        self.detail = str(detail) if detail is not None else None
+        self.type = str(type) if type is not None else None
         self.instance = str(instance) if instance is not None else None
         self.status = status
         if len(kwargs) > 0:
             self.extra_info = {
                 str(k): str(v) if v is not None else None
-                for k, v in kwargs.items() }
+                for k, v in kwargs.items()}
         if instance is None:
             try:
                 self.instance = request.url

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -1619,10 +1619,6 @@ components:
           description: |
             A timestamp for the start time of the build
           example: 1616427012.0
-        last_logs:
-          type: string
-          description: "Last lines of the build log, if available"
-          example: "[INFO] Workflow test passed"
       required:
         - build_id
         - suite_uuid

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -1692,7 +1692,7 @@ components:
         roc_instance:
           type: string
           description: |
-            RO-Crate identifier of the test instance if the instance comes 
+            RO-Crate identifier of the test instance if the instance comes
             from a Workflow RO-Crate
           example: "#test1_1"
           readOnly: true

--- a/tests/unit/api/controllers/test_instances.py
+++ b/tests/unit/api/controllers/test_instances.py
@@ -163,7 +163,6 @@ def test_get_instance_build_last_logs_by_user(m, request_context, mock_user):
     m.get_user_workflow_version.assert_called_once()
     assert isinstance(response, dict), "Unexpected response type"
     logger.debug("The loaded instance: %r", response)
-    assert len(response["last_logs"]) <= 131072, "Unexpected log length: it should be limited to the last 131072 bytes"
 
 
 @patch("lifemonitor.api.controllers.lm")


### PR DESCRIPTION
This PR removes the last_logs property from the BuildSummary schema, addressing issue #94.  It also includes some other small things, and in particular a fix to the exception handling code in `lifemonitor.api.controllers.workflows_delete` and `lifemonitor.api.controllers.instances_delete_by_id`.