### PR TITLE
Add specification responses from posting workflows

### DIFF
--- a/docker/lifemonitor.Dockerfile
+++ b/docker/lifemonitor.Dockerfile
@@ -55,7 +55,7 @@ COPY --chown=lm:lm lifemonitor /lm/lifemonitor
 ##################################################################
 FROM node:14.16.0-alpine3.12 as node
 
-RUN mkdir -p /static && apk add bash
+RUN mkdir -p /static && apk add --no-cache bash
 WORKDIR /static/src
 COPY lifemonitor/static/src/package.json package.json
 RUN npm install

--- a/examples/1_WorkflowRegistrySetup.ipynb
+++ b/examples/1_WorkflowRegistrySetup.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* Registries are the main type of actors allowed to interact with LifeMonitor"
+    "* Registries are one of the types of actors that can interact with LifeMonitor"
    ]
   },
   {
@@ -42,6 +42,35 @@
    "metadata": {},
    "source": [
     "* The reference model of workflow registry we consider is [Seek](https://github.com/seek4science/seek) (aka **WorkflowHub**) which is actually the only supported at the moment. But, in principle, every type of workflow registry which, like WorkflowHub, supports OAuth2 as authorization protocol can be easily integrated in LifeMonitor."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Start your local services"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Clone the [LifeMonitor repository](https://github.com/crs4/life_monitor.git) and `cd` into its directory.\n",
+    "\n",
+    "In this series of notebooks we assume you'll be using the local WorkflowHub and Jenkins instances (the ones started by the docker-compose provided).  For WorkflowHub to be accessible, you'll need to **ensure that the hostname `seek` resolves** to the host computer (this goes or any client computer from which you'll be accessing). If you're running everything locally this can be as easy as adding `seek` to the `localhost` line.\n",
+    "\n",
+    "\n",
+    "Then:\n",
+    "\n",
+    "0. `docker network create life_monitor`, to create the Docker network;\n",
+    "1. `make start`, to start the main LifeMonitor services;\n",
+    "2. `make start-aux-services`, to start the preconfigured instances of WorkflowHub and Jenkins.\n",
+    "\n",
+    "You should now have the following services up and running:\n",
+    "\n",
+    "* **LifeMonitor** @ https://localhost:8443\n",
+    "* **WorkflowHub** @ https://seek:3000\n",
+    "* **Jenkins** @ http://localhost:8080\n"
    ]
   },
   {
@@ -84,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -194,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -241,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {

--- a/examples/2_WorkflowRegistryAuthorize.ipynb
+++ b/examples/2_WorkflowRegistryAuthorize.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n"
+    "Before executing this notebook, complete [step 1](./1_WorkflowRegistrySetup.ipynb).\n"
    ]
   },
   {

--- a/examples/3_WorkflowRegistryUsers.ipynb
+++ b/examples/3_WorkflowRegistryUsers.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n"
+    "Before executing this notebook, complete [step 2](./2_WorkflowRegistrySetup.ipynb)."
    ]
   },
   {

--- a/examples/4_WorkflowRegistryWorkflows.ipynb
+++ b/examples/4_WorkflowRegistryWorkflows.ipynb
@@ -562,7 +562,7 @@
     {
      "data": {
       "text/plain": [
-       "{'wf_uuid': '478b43f0-8650-0139-d67a-0242ac1b0005', 'wf_version': '1'}"
+       "{'uuid': '478b43f0-8650-0139-d67a-0242ac1b0005', 'wf_version': '1', 'name': 'sort-and-change-case'}"
       ]
      },
      "execution_count": 17,
@@ -584,7 +584,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wf_uuid = data['wf_uuid']\n",
+    "wf_uuid = data['uuid']\n",
     "wf_version = data['wf_version']"
    ]
   },

--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -275,7 +275,7 @@ def workflows_post(body, _registry=None, _submitter_id=None):
             authorization=body.get('authorization', None)
         )
         logger.debug("workflows_post. Created workflow '%s' (ver.%s)", w.uuid, w.version)
-        return {'wf_uuid': str(w.workflow.uuid), 'wf_version': w.version}, 201
+        return {'uuid': str(w.workflow.uuid), 'wf_version': w.version, 'name': w.name}, 201
     except KeyError as e:
         return lm_exceptions.report_problem(400, "Bad Request", extra_info={"exception": str(e)},
                                             detail=messages.input_data_missing)

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -221,7 +221,7 @@ paths:
                 - $ref: "#/components/schemas/RegistryWorkflowVersion"
       responses:
         "201":
-          description: Workflow created by this operation
+          $ref: "#/components/responses/WorkflowRegistered"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -278,7 +278,7 @@ paths:
               $ref: "#/components/schemas/RegistryWorkflowVersion"
       responses:
         "201":
-          description: Workflow created by this operation
+          $ref: "#/components/responses/WorkflowRegistered"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -339,7 +339,7 @@ paths:
                 - $ref: "#/components/schemas/RegistryWorkflowVersion"
       responses:
         "201":
-          description: The workflow created by this operation
+          $ref: "#/components/responses/WorkflowRegistered"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -393,7 +393,7 @@ paths:
               $ref: "#/components/schemas/GenericWorkflowVersion"
       responses:
         "201":
-          description: The workflow created by this operation
+          $ref: "#/components/responses/WorkflowRegistered"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -1093,6 +1093,14 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
 
+    WorkflowRegistered:
+      description: A new workflow has been registered.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Workflow"
+
+
   schemas:
     User:
       type: object
@@ -1486,6 +1494,9 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/BuildSummary"
+          required:
+            - aggregate_test_status
+            - version
 
     WorkflowVersionStatus:
       allOf:
@@ -1502,6 +1513,10 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/BuildSummary"
+          required:
+            - version
+            - workflow
+            - aggregate_test_status
 
     AggregateTestStatus:
       type: string

--- a/tests/integration/api/controllers/test_registries.py
+++ b/tests/integration/api/controllers/test_registries.py
@@ -158,7 +158,7 @@ def test_workflow_registration_by_roc_link(app_client, client_auth_method,
     utils.assert_status_code(201, response.status_code)
     data = json.loads(response.data)
     logger.debug("Response data: %r", data)
-    assert data['wf_uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
+    assert data['uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
         "Response should be equal to the workflow UUID"
 
 
@@ -181,7 +181,7 @@ def test_user_workflow_registration_by_roc_link(app_client, client_auth_method,
     utils.assert_status_code(201, response.status_code)
     data = json.loads(response.data)
     logger.debug("Response data: %r", data)
-    assert data['wf_uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
+    assert data['uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
         "Response should be equal to the workflow UUID"
 
 
@@ -204,7 +204,7 @@ def test_workflow_registration_by_identifier(app_client, client_auth_method,
     utils.assert_status_code(201, response.status_code)
     data = json.loads(response.data)
     logger.debug("Response data: %r", data)
-    assert data['wf_uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
+    assert data['uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
         "Response should be equal to the workflow UUID"
 
 
@@ -227,7 +227,7 @@ def test_registry_user_workflow_registration_by_identifier(app_client, client_au
     utils.assert_status_code(201, response.status_code)
     data = json.loads(response.data)
     logger.debug("Response data: %r", data)
-    assert data['wf_uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
+    assert data['uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
         "Response should be equal to the workflow UUID"
 
 
@@ -253,7 +253,7 @@ def test_workflow_registration_same_workflow_by_different_users(app_client, clie
             utils.assert_status_code(201, response.status_code)
             data = json.loads(response.data)
             logger.debug("Response data: %r", data)
-            assert data['wf_uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
+            assert data['uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
                 "Response should be equal to the workflow UUID"
         else:
             utils.assert_status_code(409, response.status_code)

--- a/tests/integration/api/controllers/test_users.py
+++ b/tests/integration/api/controllers/test_users.py
@@ -125,7 +125,7 @@ def test_generic_workflow_registration(app_client, client_auth_method,
     utils.assert_status_code(201, response.status_code)
     data = json.loads(response.data)
     logger.debug("Response data: %r", data)
-    assert data['wf_uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
+    assert data['uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
         "Response should be equal to the workflow UUID"
 
 
@@ -152,7 +152,7 @@ def test_generic_workflow_registration_wo_uuid(app_client, client_auth_method,
     logger.debug("Response data: %r", data)
     assert data['wf_version'] == workflow['version'], \
         "Response should be equal to the workflow UUID"
-    assert data['wf_uuid'], "Workflow UUID was not generated or returned"
+    assert data['uuid'], "Workflow UUID was not generated or returned"
 
 
 @pytest.mark.parametrize("client_auth_method", [
@@ -174,7 +174,7 @@ def test_registry_workflow_registration(app_client, client_auth_method,
     utils.assert_status_code(201, response.status_code)
     data = json.loads(response.data)
     logger.debug("Response data: %r", data)
-    assert data['wf_uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
+    assert data['uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
         "Response should be equal to the workflow UUID"
 
 
@@ -204,7 +204,7 @@ def test_registry_workflow_registration_same_workflow_by_different_users(app_cli
             utils.assert_status_code(201, response.status_code)
             data = json.loads(response.data)
             logger.debug("Response data: %r", data)
-            assert data['wf_uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
+            assert data['uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
                 "Response should be equal to the workflow UUID"
         else:
             utils.assert_status_code(409, response.status_code)

--- a/tests/integration/api/controllers/test_workflows.py
+++ b/tests/integration/api/controllers/test_workflows.py
@@ -89,12 +89,12 @@ def test_workflow_registration_check_default_name(app_client, client_auth_method
     utils.assert_status_code(201, response.status_code)
     data = json.loads(response.data)
     logger.debug("Response data: %r", data)
-    assert data['wf_uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
+    assert data['uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
         "Response should be equal to the workflow UUID"
 
-    wf = utils.get_workflow_data(data['wf_uuid'])
+    wf = utils.get_workflow_data(data['uuid'])
     assert wf, "Unable to load workflow data"
-    assert str(wf.uuid) == data['wf_uuid'], "Unexpected workflow uuid"
+    assert str(wf.uuid) == data['uuid'], "Unexpected workflow uuid"
     assert wf.latest_version.version == data['wf_version'], "Unexpected workflow uuid"
     assert wf.name == workflow['name'], "Unexpected workflow name"
 
@@ -117,12 +117,12 @@ def test_workflow_registration_check_custom_name(app_client, client_auth_method,
     utils.assert_status_code(201, response.status_code)
     data = json.loads(response.data)
     logger.debug("Response data: %r", data)
-    assert data['wf_uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
+    assert data['uuid'] == workflow['uuid'] and data['wf_version'] == workflow['version'], \
         "Response should be equal to the workflow UUID"
 
-    wf = utils.get_workflow_data(data['wf_uuid'])
+    wf = utils.get_workflow_data(data['uuid'])
     assert wf, "Unable to load workflow data"
-    assert str(wf.uuid) == data['wf_uuid'], "Unexpected workflow uuid"
+    assert str(wf.uuid) == data['uuid'], "Unexpected workflow uuid"
     assert wf.latest_version.version == data['wf_version'], "Unexpected workflow uuid"
     assert wf.name == body['name'], "Unexpected workflow name"
 

--- a/tests/integration/api/services/test_github_service.py
+++ b/tests/integration/api/services/test_github_service.py
@@ -46,16 +46,16 @@ def test_github_service(app_client, client_auth_method,
     utils.assert_status_code(201, response.status_code)
     registration_data = response.json
 
-    assert registration_data['wf_uuid'] == wf['uuid']
+    assert registration_data['uuid'] == wf['uuid']
     assert registration_data['wf_version'] == wf['version']
 
     # verify that the workflow is registered
-    response = app_client.get(f"/workflows/{registration_data['wf_uuid']}",
+    response = app_client.get(f"/workflows/{registration_data['uuid']}",
                               query_string={'previous_versions': False},
                               headers=user1_auth)
     utils.assert_status_code(200, response.status_code)
 
-    response = app_client.get(f"/workflows/{registration_data['wf_uuid']}/status", headers=user1_auth)
+    response = app_client.get(f"/workflows/{registration_data['uuid']}/status", headers=user1_auth)
     utils.assert_status_code(200, response.status_code)
 
     status_data = response.json

--- a/tests/integration/api/services/test_services.py
+++ b/tests/integration/api/services/test_services.py
@@ -137,7 +137,7 @@ def test_workflow_registry_generic_link(app_client, user1):  # , valid_workflow)
         "Unexpected workflow ID"
     # assert workflow.external_id is not None, "External ID must be computed if not provided"
     # assert workflow.external_id == w["external_id"], "Invalid external ID"
-    assert workflow.submitter == user1["user"], "Inavalid submitter user"
+    assert workflow.submitter == user1["user"], "Invalid submitter user"
     # inspect the suite/test type
     assert len(workflow.test_suites) == 1, "Expected number of test suites 1"
     suite = workflow.test_suites[0]

--- a/tests/unit/api/controllers/test_workflows.py
+++ b/tests/unit/api/controllers/test_workflows.py
@@ -151,7 +151,7 @@ def test_post_workflow_by_user(m, request_context, mock_user):
     m.get_workflow_registry_by_generic_reference.assert_called_once_with(data["registry"]), \
         "get_workflow_registry_by_uri should be used"
     assert_status_code(201, response[1])
-    assert response[0]["wf_uuid"] == data['uuid'] and \
+    assert response[0]["uuid"] == data['uuid'] and \
         response[0]["wf_version"] == data['version']
 
 
@@ -203,7 +203,7 @@ def test_post_workflow_by_registry(m, request_context, mock_registry):
     response = controllers.workflows_post(body=data)
     logger.debug("Response: %r", response)
     assert_status_code(201, response[1])
-    assert response[0]["wf_uuid"] == data['uuid'] and \
+    assert response[0]["uuid"] == data['uuid'] and \
         response[0]["wf_version"] == data['version']
 
 


### PR DESCRIPTION
This PR adds specifications for the successful (i.e., http 201) responses returned from calls registering workflows:

* POST /registries/current/workflows
* POST /registries/{registry_uuid}/workflows
* POST /users/{user_id}/workflows
* POST /users/current/workflows

For homogeneity, the responses reuse the already-defined `Workflow` schema.  However, this schema defines the same properties as the original responses **but** calls the workflow uuid `uuid` instead of `wf_uuid`.  Thus, this PR introduces an incompatible change in the API in that the responses to the above-listed POST call contain a `uuid` property instead of `wf_uuid`.  The schema also adds the workflow `name` to the response.

The PR also defines as **required** the following schema properties:
* WorkflowStatus
    - aggregate_test_status
     - version
* WorkflowVersionStatus
    - workflow
    - aggregate_test_status
    - version

Consider bumping the API version.