### PR TITLE
Expose links to TestingServices

### DIFF
--- a/lifemonitor/api/models/services/github.py
+++ b/lifemonitor/api/models/services/github.py
@@ -182,7 +182,7 @@ class GithubTestingService(TestingService):
         try:
             build_number = int(build_number)
         except ValueError as e:
-            raise lm_exceptions.LifeMonitorException("Invalid 'build_numer'",
+            raise lm_exceptions.LifeMonitorException("Invalid 'build_number'",
                                                      details="The build parameter must be an integer: {0}".format(str(e)), status=400)
         for run in self._iter_runs(test_instance):
             if run.id == build_number:

--- a/lifemonitor/api/models/services/github.py
+++ b/lifemonitor/api/models/services/github.py
@@ -167,7 +167,11 @@ class GithubTestingService(TestingService):
         # obvious way to istantiate a PyGithub WorkflowRun object given a build
         # number -- but there's has to be a way.  We can easily asseble the URL
         # of the request to directly retrive the data we need here.
-        assert isinstance(build_number, int)
+        try:
+            build_number = int(build_number)
+        except ValueError as e:
+            raise lm_exceptions.LifeMonitorException("Invalid 'build_numer'",
+                                                     details="The build parameter must be an integer: {0}".format(str(e)), status=400)
         for run in self._iter_runs(test_instance):
             if run.id == build_number:
                 return GithubTestBuild(self, test_instance, run)

--- a/lifemonitor/api/models/services/github.py
+++ b/lifemonitor/api/models/services/github.py
@@ -185,6 +185,10 @@ class GithubTestingService(TestingService):
                 return GithubTestBuild(self, test_instance, run)
         raise lm_exceptions.EntityNotFoundException(models.TestBuild, entity_id=build_number)
 
+    def get_test_build_external_link(self, test_build: models.TestBuild) -> str:
+        repo = test_build.test_instance.testing_service._get_repo(test_build.test_instance)
+        return f'https://github.com/{repo.full_name}/actions/runs/{test_build.id}'
+
     @classmethod
     def _parse_workflow_url(cls, resource: str) -> Tuple[str, str, str]:
         """
@@ -292,5 +296,4 @@ class GithubTestBuild(models.TestBuild):
 
     @property
     def external_link(self) -> str:
-        repo = self.testing_service._get_repo(self.test_instance)
-        return f'https://github.com/{repo.full_name}/actions/runs/{self.id}'
+        return self.testing_service.get_test_build_external_link(self)

--- a/lifemonitor/api/models/services/github.py
+++ b/lifemonitor/api/models/services/github.py
@@ -148,6 +148,10 @@ class GithubTestingService(TestingService):
             if status is None or run.status == status:
                 yield run
 
+    def get_instance_external_link(self, test_instance: models.TestInstance) -> str:
+        _, repo_full_name, workflow_id = self._parse_workflow_url(test_instance.resource)
+        return f'https://github.com/{repo_full_name}/actions/workflows/{workflow_id}'
+
     def get_last_test_build(self, test_instance: models.TestInstance) -> Optional[GithubTestBuild]:
         for run in self._iter_runs(test_instance, status=self.GithubStatus.COMPLETED):
             return GithubTestBuild(self, test_instance, run)

--- a/lifemonitor/api/models/services/jenkins.py
+++ b/lifemonitor/api/models/services/jenkins.py
@@ -78,6 +78,9 @@ class JenkinsTestingService(TestingService):
                 f"Unable to get the Jenkins job from the resource {job_name}")
         return job_name
 
+    def get_instance_external_link(self, test_instance: models.TestInstance) -> str:
+        return self.get_project_metadata(test_instance)['url']
+
     def get_last_test_build(self, test_instance: models.TestInstance) -> Optional[JenkinsTestBuild]:
         metadata = self.get_project_metadata(test_instance)
         if 'lastBuild' in metadata and metadata['lastBuild']:

--- a/lifemonitor/api/models/services/jenkins.py
+++ b/lifemonitor/api/models/services/jenkins.py
@@ -22,12 +22,14 @@ from __future__ import annotations
 
 import logging
 import re
+import urllib
 from typing import Optional
 
-import jenkins
 import lifemonitor.api.models as models
 import lifemonitor.exceptions as lm_exceptions
 from lifemonitor.lang import messages
+
+import jenkins
 
 from .service import TestingService
 
@@ -196,3 +198,7 @@ class JenkinsTestBuild(models.TestBuild):
     @property
     def url(self) -> str:
         return self.metadata['url']
+
+    @property
+    def external_link(self) -> str:
+        return urllib.parse.urljoin(self.url, "console")

--- a/lifemonitor/api/models/services/jenkins.py
+++ b/lifemonitor/api/models/services/jenkins.py
@@ -130,6 +130,9 @@ class JenkinsTestingService(TestingService):
         except jenkins.JenkinsException as e:
             raise lm_exceptions.TestingServiceException(e)
 
+    def get_test_build_external_link(self, test_build: models.TestBuild) -> str:
+        return urllib.parse.urljoin(test_build.url, "console")
+
     def get_test_build_output(self, test_instance: models.TestInstance, build_number, offset_bytes=0, limit_bytes=131072):
         try:
             logger.debug("test_instance '%r', build_number '%r'", test_instance.name, build_number)
@@ -201,4 +204,4 @@ class JenkinsTestBuild(models.TestBuild):
 
     @property
     def external_link(self) -> str:
-        return urllib.parse.urljoin(self.url, "console")
+        return self.testing_service.get_test_build_external_link(self)

--- a/lifemonitor/api/models/services/service.py
+++ b/lifemonitor/api/models/services/service.py
@@ -158,6 +158,9 @@ class TestingService(db.Model, ModelMixin):
     def is_workflow_healthy(self, test_instance: models.TestInstance) -> bool:
         return self.get_last_test_build(test_instance).is_successful()
 
+    def get_instance_external_link(self, test_instance: models.TestInstance) -> str:
+        raise lm_exceptions.NotImplementedException()
+
     def get_last_test_build(self, test_instance: models.TestInstance) -> models.TestBuild:
         raise lm_exceptions.NotImplementedException()
 

--- a/lifemonitor/api/models/services/service.py
+++ b/lifemonitor/api/models/services/service.py
@@ -170,6 +170,9 @@ class TestingService(db.Model, ModelMixin):
     def get_test_build(self, test_instance: models.TestInstance, build_number: int) -> models.TestBuild:
         raise lm_exceptions.NotImplementedException()
 
+    def get_test_build_external_link(self, test_build: models.TestBuild) -> str:
+        raise lm_exceptions.NotImplementedException()
+
     def get_test_builds(self, test_instance: models.TestInstance, limit: int = 10) -> list:
         raise lm_exceptions.NotImplementedException()
 

--- a/lifemonitor/api/models/services/travis.py
+++ b/lifemonitor/api/models/services/travis.py
@@ -121,6 +121,11 @@ class TravisTestingService(TestingService):
         except Exception as e:
             raise TestingServiceException(e)
 
+    def get_instance_external_link(self, test_instance: models.TestInstance) -> str:
+        testing_service = test_instance.testing_service
+        repo_id = testing_service.get_repo_id(test_instance, quote=False)
+        return urllib.parse.urljoin(testing_service.base_url, f'{repo_id}')
+
     def get_last_test_build(self, test_instance: models.TestInstance) -> Optional[models.TravisTestBuild]:
         return self._get_last_test_build(test_instance)
 

--- a/lifemonitor/api/models/services/travis.py
+++ b/lifemonitor/api/models/services/travis.py
@@ -167,6 +167,11 @@ class TravisTestingService(TestingService):
                                               detail=str(response.content))
         return models.TravisTestBuild(self, test_instance, response)
 
+    def get_test_build_external_link(self, test_build: models.TestBuild) -> str:
+        testing_service = test_build.test_instance.testing_service
+        repo_id = testing_service.get_repo_id(test_build.test_instance, quote=False)
+        return urllib.parse.urljoin(testing_service.base_url, f'{repo_id}/builds/{test_build.id}')
+
     def get_test_build_output(self, test_instance: models.TestInstance, build_number, offset_bytes=0, limit_bytes=131072):
         try:
             _metadata = self._get(f"/build/{build_number}/jobs")
@@ -264,6 +269,4 @@ class TravisTestBuild(models.TestBuild):
 
     @property
     def external_link(self) -> str:
-        testing_service = self.test_instance.testing_service
-        repo_id = testing_service.get_repo_id(self.test_instance, quote=False)
-        return urllib.parse.urljoin(testing_service.base_url, f'{repo_id}/builds/{self.id}')
+        return self.testing_service.get_test_build_external_link(self)

--- a/lifemonitor/api/models/testsuites/testbuild.py
+++ b/lifemonitor/api/models/testsuites/testbuild.py
@@ -102,6 +102,11 @@ class TestBuild(ABC):
     def url(self) -> str:
         pass
 
+    @property
+    @abstractmethod
+    def external_link(self) -> str:
+        pass
+
     def get_output(self, offset_bytes=0, limit_bytes=131072):
         return self.testing_service.get_test_build_output(self.test_instance, self.id, offset_bytes, limit_bytes)
 

--- a/lifemonitor/api/models/testsuites/testinstance.py
+++ b/lifemonitor/api/models/testsuites/testinstance.py
@@ -83,6 +83,10 @@ class TestInstance(db.Model, ModelMixin):
         return self.type != 'unmanaged'
 
     @property
+    def external_link(self):
+        return self.testing_service.get_instance_external_link(self)
+
+    @property
     def last_test_build(self):
         return self.testing_service.get_last_test_build(self)
 

--- a/lifemonitor/api/serializers.py
+++ b/lifemonitor/api/serializers.py
@@ -68,7 +68,7 @@ class WorkflowSchema(ResourceMetadataSchema):
 
 
 class RegistryWorkflowSchema(WorkflowSchema):
-    registry = fields.Nested(WorkflowRegistrySchema(exclude=('meta',)), attribute="")
+    registry = fields.Nested(WorkflowRegistrySchema(exclude=('meta', 'links')), attribute="")
 
 
 class VersionDetailsSchema(BaseSchema):
@@ -116,7 +116,7 @@ class WorkflowVersionSchema(ResourceSchema):
     uuid = fields.String(attribute="workflow.uuid")
     name = ma.auto_field()
     version = fields.Method("get_version")
-    registry = ma.Nested(WorkflowRegistrySchema(exclude=('meta',)),
+    registry = ma.Nested(WorkflowRegistrySchema(exclude=('meta', 'links')),
                          attribute="workflow_registry")
 
     rocrate_metadata = False
@@ -187,6 +187,15 @@ class TestInstanceSchema(ResourceMetadataSchema):
     resource = ma.auto_field()
     managed = fields.Boolean(attribute="managed")
     service = fields.Method("get_testing_service")
+    links = fields.Method('get_links')
+
+    def get_links(self, obj):
+        links = {
+            'origin': obj.external_link
+        }
+        if self._self_link:
+            links['self'] = self.self_link
+        return links
 
     def get_testing_service(self, obj):
         logger.debug("Test current obj: %r", obj)
@@ -215,8 +224,17 @@ class BuildSummarySchema(ResourceMetadataSchema):
     build_id = fields.String(attribute="id")
     suite_uuid = fields.String(attribute="test_instance.test_suite.uuid")
     status = fields.String()
-    instance = ma.Nested(TestInstanceSchema(exclude=('meta',)), attribute="test_instance")
+    instance = ma.Nested(TestInstanceSchema(self_link=False, exclude=('meta',)), attribute="test_instance")
     timestamp = fields.String()
+    links = fields.Method('get_links')
+
+    def get_links(self, obj):
+        links = {
+            'origin': obj.external_link
+        }
+        if self._self_link:
+            links['self'] = self.self_link
+        return links
 
 
 class WorkflowVersionListItem(WorkflowSchema):
@@ -233,7 +251,7 @@ class WorkflowVersionListItem(WorkflowSchema):
     def get_latest_build(self, workflow):
         latest_builds = workflow.latest_version.status.latest_builds
         if latest_builds and len(latest_builds) > 0:
-            return BuildSummarySchema(exclude=('meta',)).dump(latest_builds[0])
+            return BuildSummarySchema(exclude=('meta', 'links')).dump(latest_builds[0])
         return None
 
 
@@ -245,7 +263,7 @@ class ListOfWorkflows(ListOfItems):
         self.workflow_status = workflow_status
 
     def get_items(self, obj):
-        exclude = ("meta",) if self.workflow_status else ("meta", "status")
+        exclude = ('meta', 'links') if self.workflow_status else ('meta', 'links', "status")
         return [self.__item_scheme__(exclude=exclude, many=False).dump(_) for _ in obj] \
             if self.__item_scheme__ else None
 
@@ -258,7 +276,7 @@ class WorkflowStatusSchema(WorkflowVersionSchema):
         model = models.WorkflowStatus
 
     aggregate_test_status = fields.String(attribute="status.aggregated_status")
-    latest_builds = ma.Nested(BuildSummarySchema(exclude=('meta',)),
+    latest_builds = ma.Nested(BuildSummarySchema(exclude=('meta', 'links')),
                               attribute="status.latest_builds", many=True)
 
 
@@ -272,7 +290,7 @@ class SuiteSchema(ResourceMetadataSchema):
     uuid = ma.auto_field()
     roc_suite = fields.String(attribute="roc_suite")
     definition = fields.Method("get_definition")
-    instances = fields.Nested(TestInstanceSchema(exclude=('meta',)),
+    instances = fields.Nested(TestInstanceSchema(self_link=False, exclude=('meta',)),
                               attribute="test_instances", many=True)
 
     def get_definition(self, obj):
@@ -300,7 +318,7 @@ class SuiteStatusSchema(ResourceMetadataSchema):
 
     suite_uuid = fields.String(attribute="suite.uuid")
     status = fields.String(attribute="aggregated_status")
-    latest_builds = fields.Nested(BuildSummarySchema(exclude=('meta',)), many=True)
+    latest_builds = fields.Nested(BuildSummarySchema(exclude=('meta', 'links')), many=True)
 
 
 class ListOfTestInstancesSchema(ListOfItems):

--- a/lifemonitor/api/serializers.py
+++ b/lifemonitor/api/serializers.py
@@ -87,7 +87,7 @@ class VersionDetailsSchema(BaseSchema):
     def get_rocrate(self, obj):
         rocrate = {
             'links': {
-                'external': obj.uri,
+                'origin': obj.uri,
                 'download': urljoin(lm_utils.get_external_server_url(), f"ro_crates/{obj.id}/download")
             }
         }

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -1100,7 +1100,6 @@ components:
           schema:
             $ref: "#/components/schemas/Workflow"
 
-
   schemas:
     User:
       type: object
@@ -1634,6 +1633,13 @@ components:
           description: |
             A timestamp for the start time of the build
           example: 1616427012.0
+        links:
+          type: object
+          properties:
+            origin:
+              type: string
+              description: Link to the test build on the testing service
+              example: "https://github.com/crs4/life_monitor/actions/runs/968650807"
       required:
         - build_id
         - suite_uuid
@@ -1744,6 +1750,13 @@ components:
               description: |
                 The relative path of the test project on the testing service
               example: github/seek4science/seek
+            links:
+              type: object
+              properties:
+                origin:
+                  type: string
+                  description: Link to the test instance on the testing service
+                  example: "https://github.com/crs4/life_monitor/workflows/docs.yaml"
           required:
             - service
             - resource

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -503,7 +503,7 @@ paths:
                                 {
                                   links:
                                     {
-                                      external: "https://dev.workflowhub.eu/workflows/142/content_blobs/240/download",
+                                      origin: "https://dev.workflowhub.eu/workflows/142/content_blobs/240/download",
                                       download: "https://api.lifemonitor.eu/ro_crates/10/download",
                                     },
                                 },
@@ -1272,7 +1272,7 @@ components:
         links:
           type: object
           properties:
-            external:
+            origin:
               type: string
               description: |
                 The link to the workflow RO-Crate used to register the workflow on LifeMonitor
@@ -1443,7 +1443,7 @@ components:
                       {
                         links:
                           {
-                            external: "https://dev.workflowhub.eu/workflows/142/content_blobs/240/download",
+                            origin: "https://dev.workflowhub.eu/workflows/142/content_blobs/240/download",
                             download: "https://api.lifemonitor.eu/ro_crates/10/download",
                           },
                       },


### PR DESCRIPTION
This PR extends the API specs and implementation with the `links.origin` property that links `TestInstances` and `TestBuilds` registered on LM to the corresponding entities on the actual testing services (Travis, Github, Jenkins). 



`TestBuild` example:

```javascript
{
  build_id: 167444,
  suite_uuid: "e3208b02-69b6-4e32-a3dc-b93967d30e2c",
  status: "passed",
  ....,
  timestamp: 1616427012,
  duration: 2648,
  links: {
    origin: "https://github.com/crs4/life_monitor/actions/runs/968650807"
  }
}
```