### PR TITLE
Feature/enable db migrations

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -51,7 +51,7 @@ services:
     entrypoint: /bin/bash
     restart: "no"
     command: |
-      -c "wait-for-postgres.sh && flask db init"
+      -c "wait-for-postgres.sh && flask init db"
     depends_on:
       - "db"
     env_file: *env_file

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,7 +10,7 @@ services:
     restart: "no"
     entrypoint: /bin/bash
     command: |
-      -c "wait-for-postgres.sh && flask db init && /usr/local/bin/lm_entrypoint.sh"
+      -c "wait-for-postgres.sh && flask init db && /usr/local/bin/lm_entrypoint.sh"
     environment:
       - "FLASK_ENV=testingSupport"
       - "HOME=/lm"

--- a/k8s/templates/init-job.yaml
+++ b/k8s/templates/init-job.yaml
@@ -12,7 +12,7 @@ spec:
         image: "{{ .Values.lifemonitor.image }}"
         imagePullPolicy: {{ .Values.lifemonitor.imagePullPolicy }}
         command: ["/bin/sh","-c"]
-        args: ["wait-for-postgres.sh && flask db init"]
+        args: ["wait-for-postgres.sh && flask init db"]
         env:
 {{ include "lifemonitor.common-env" . | indent 10 }}
         volumeMounts:

--- a/lifemonitor/app.py
+++ b/lifemonitor/app.py
@@ -22,9 +22,11 @@ import logging
 import os
 import time
 
-import lifemonitor.config as config
 from flask import Flask, jsonify, redirect, request
 from flask_cors import CORS
+from flask_migrate import Migrate
+
+import lifemonitor.config as config
 from lifemonitor import __version__ as version
 from lifemonitor.routes import register_routes
 
@@ -111,6 +113,8 @@ def initialize_app(app, app_context, prom_registry=None):
     config.configure_logging(app)
     # configure app DB
     db.init_app(app)
+    # initialize Migration engine
+    Migrate(app, db)
     # configure serializer engine (Flask Marshmallow)
     ma.init_app(app)
     # configure app routes

--- a/lifemonitor/commands/db.py
+++ b/lifemonitor/commands/db.py
@@ -20,44 +20,47 @@
 
 import logging
 
-from flask import Blueprint, current_app
+from flask import current_app
+from flask.blueprints import Blueprint
 from flask.cli import with_appcontext
+from flask_migrate import current, stamp, upgrade
 from lifemonitor.auth.models import User
 
 # set module level logger
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 # define the blueprint for DB commands
-blueprint = Blueprint('db', __name__)
+blueprint = Blueprint('init', __name__)
 
 
-@blueprint.cli.command('init')
+@blueprint.cli.command('db')
 @with_appcontext
-def db_init():
+def init_db():
     """
-    Initialize the DB
+    Initialize LifeMonitor App
     """
-    from lifemonitor.db import create_db, db
-    logger.debug("Initializing DB...")
-    create_db(settings=current_app.config)
-    db.create_all()
-    logger.info("DB initialized")
-    # create a default admin user if not exists
-    admin = User.find_by_username('admin')
-    if not admin:
-        admin = User('admin')
-        admin.password = current_app.config["LIFEMONITOR_ADMIN_PASSWORD"]
-        db.session.add(admin)
-        db.session.commit()
+    from lifemonitor.db import create_db, db, db_initialized
 
-
-@blueprint.cli.command('clean')
-@with_appcontext
-def db_clean():
-    """ Clean up DB """
-    from lifemonitor.db import db
-    db.session.rollback()
-    for table in reversed(db.metadata.sorted_tables):
-        db.session.execute(table.delete())
-    db.session.commit()
-    logger.info("DB deleted")
+    is_initialized = db_initialized()
+    logger.info("LifeMonitor app initialized: %r", is_initialized)
+    if is_initialized:
+        logger.info("Trying to....")
+        # Apply migrations
+        logger.info("Applying migrations...")
+        upgrade()
+        logger.info("Migrations applied!")
+    else:
+        logger.debug("Initializing DB...")
+        create_db(settings=current_app.config)
+        db.create_all()
+        stamp()
+        logger.info("Current DB revision...")
+        current()
+        logger.info("DB initialized")
+        # create a default admin user if not exists
+        admin = User.find_by_username('admin')
+        if not admin:
+            admin = User('admin')
+            admin.password = current_app.config["LIFEMONITOR_ADMIN_PASSWORD"]
+            db.session.add(admin)
+            db.session.commit()

--- a/lifemonitor/commands/db.py
+++ b/lifemonitor/commands/db.py
@@ -25,7 +25,7 @@ import click
 from flask import current_app
 from flask.blueprints import Blueprint
 from flask.cli import with_appcontext
-from flask_migrate import stamp, upgrade
+from flask_migrate import current, stamp, upgrade
 from lifemonitor.auth.models import User
 
 # set module level logger
@@ -60,11 +60,13 @@ def init_db(revision):
         logger.info(f"Applying migrations up to revision '{revision}'...")
         upgrade(revision=revision)
         logger.info("Migrations applied!")
+        logger.info("Current revision: %r", db_revision())
     else:
         logger.debug("Initializing DB...")
         create_db(settings=current_app.config)
         db.create_all()
         stamp()
+        current()
         logger.info("DB initialized")
         # create a default admin user if not exists
         admin = User.find_by_username('admin')
@@ -73,4 +75,3 @@ def init_db(revision):
             admin.password = current_app.config["LIFEMONITOR_ADMIN_PASSWORD"]
             db.session.add(admin)
             db.session.commit()
-    logger.info("Current revision: %r", db_revision())

--- a/lifemonitor/commands/db.py
+++ b/lifemonitor/commands/db.py
@@ -25,7 +25,7 @@ import click
 from flask import current_app
 from flask.blueprints import Blueprint
 from flask.cli import with_appcontext
-from flask_migrate import current, stamp, upgrade
+from flask_migrate import stamp, upgrade
 from lifemonitor.auth.models import User
 
 # set module level logger
@@ -74,10 +74,3 @@ def init_db(revision):
             db.session.add(admin)
             db.session.commit()
     logger.info("Current revision: %r", db_revision())
-
-
-@blueprint.cli.command('rev')
-@with_appcontext
-def get_rev():
-    from lifemonitor.db import create_db, db, db_initialized, db_revision
-    print(db_revision())

--- a/lifemonitor/config.py
+++ b/lifemonitor/config.py
@@ -121,7 +121,7 @@ def get_config_by_name(name, settings=None):
         if settings is None:
             settings = load_settings(config)
         if settings and "SQLALCHEMY_DATABASE_URI" not in settings:
-            settings["SQLALCHEMY_DATABASE_URI"] = db_uri(settings)
+            settings["SQLALCHEMY_DATABASE_URI"] = db_uri(settings=settings)
         # always set the FLASK_APP_CONFIG_FILE variable to the environment
         if settings and "FLASK_APP_CONFIG_FILE" in settings:
             os.environ["FLASK_APP_CONFIG_FILE"] = settings["FLASK_APP_CONFIG_FILE"]

--- a/lifemonitor/db.py
+++ b/lifemonitor/db.py
@@ -86,8 +86,13 @@ def db_initialized(conn_params=None, settings=None, override_db_name=None):
     return db_table_exists('user', conn_params=conn_params, settings=settings, override_db_name=override_db_name)
 
 
+def db_revision(conn_params=None, settings=None, override_db_name=None):
     conn = db_connect(conn_params=conn_params, settings=settings, override_db_name=override_db_name)
     cursor = conn.cursor()
+    cursor.execute("SELECT * FROM alembic_version")
+    row = cursor.fetchone()
+    logger.debug("Row: %r", row)
+    return row[0] if row else None
 
 
 def db_table_exists(table_name: str, conn_params=None, settings=None, override_db_name=None):

--- a/lifemonitor/db.py
+++ b/lifemonitor/db.py
@@ -83,9 +83,18 @@ def db_connect(conn_params=None, settings=None, override_db_name=None):
 
 
 def db_initialized(conn_params=None, settings=None, override_db_name=None):
+    return db_table_exists('user', conn_params=conn_params, settings=settings, override_db_name=override_db_name)
+
+
     conn = db_connect(conn_params=conn_params, settings=settings, override_db_name=override_db_name)
     cursor = conn.cursor()
-    cursor.execute("SELECT * FROM information_schema.tables WHERE table_name = 'alembic_version'")
+
+
+def db_table_exists(table_name: str, conn_params=None, settings=None, override_db_name=None):
+    logger.debug(f"Checking if DB table '{table_name}' exists")
+    conn = db_connect(conn_params=conn_params, settings=settings, override_db_name=override_db_name)
+    cursor = conn.cursor()
+    cursor.execute(f"SELECT * FROM information_schema.tables WHERE table_name = '{table_name}'")
     logger.debug("%r %r", cursor.rowcount, cursor.rowcount > 1)
     return cursor.rowcount == 1
 

--- a/lifemonitor/db.py
+++ b/lifemonitor/db.py
@@ -82,6 +82,14 @@ def db_connect(conn_params=None, settings=None, override_db_name=None):
     return con
 
 
+def db_initialized(conn_params=None, settings=None, override_db_name=None):
+    conn = db_connect(conn_params=conn_params, settings=settings, override_db_name=override_db_name)
+    cursor = conn.cursor()
+    cursor.execute("SELECT * FROM information_schema.tables WHERE table_name = 'alembic_version'")
+    logger.debug("%r %r", cursor.rowcount, cursor.rowcount > 1)
+    return cursor.rowcount == 1
+
+
 def create_db(conn_params=None, settings=None, drop=False):
     if conn_params is None:
         conn_params = db_connection_params(settings)

--- a/lifemonitor/db.py
+++ b/lifemonitor/db.py
@@ -23,6 +23,7 @@ import os
 
 import psycopg2 as psy
 import psycopg2.sql as sql
+from flask import current_app
 from flask_sqlalchemy import SQLAlchemy
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
@@ -36,6 +37,8 @@ db = SQLAlchemy()
 def get_db_connection_param(name, settings=None):
     if settings and name in settings:
         return settings.get(name)
+    if current_app and name in current_app.config:
+        return current_app.config[name]
     return os.environ.get(name, None)
 
 
@@ -49,7 +52,7 @@ def db_connection_params(settings=None):
     }
 
 
-def db_uri(settings=None):
+def db_uri(settings=None, override_db_name=None):
     """
     Build URI to connect to the DataBase
     :return:
@@ -63,13 +66,12 @@ def db_uri(settings=None):
             passwd=conn_params['password'],
             host=conn_params['host'],
             port=conn_params['port'],
-            dbname=conn_params['dbname'])
+            dbname=override_db_name or conn_params['dbname'])
     return uri
 
 
-def db_connect(conn_params=None, settings=None, override_db_name=None):
-    if conn_params is None:
-        conn_params = db_connection_params(settings)
+def db_connect(settings=None, override_db_name=None):
+    conn_params = db_connection_params(settings)
 
     actual_db_name = override_db_name if override_db_name else conn_params['dbname']
     con = psy.connect(
@@ -82,12 +84,28 @@ def db_connect(conn_params=None, settings=None, override_db_name=None):
     return con
 
 
-def db_initialized(conn_params=None, settings=None, override_db_name=None):
-    return db_table_exists('user', conn_params=conn_params, settings=settings, override_db_name=override_db_name)
+def db_exists(db_name=None, settings=None):
+    actual_db_name = db_name or get_db_connection_param("POSTGRESQL_DATABASE", settings)
+    for dbname in (actual_db_name, 'postgres', 'template1', 'template0', None):
+        try:
+            conn = db_connect(settings=settings, override_db_name=actual_db_name)
+            cursor = conn.cursor()
+            cursor.execute(f"SELECT 1 FROM pg_database WHERE datname='{dbname}'")
+            if cursor.fetchone():
+                return True
+        except Exception as e:
+            logger.debug(e)
+    return False
 
 
-def db_revision(conn_params=None, settings=None, override_db_name=None):
-    conn = db_connect(conn_params=conn_params, settings=settings, override_db_name=override_db_name)
+def db_initialized(db_name=None, settings=None):
+    return db_exists(settings=settings, db_name=db_name) and \
+        db_table_exists('user', settings=settings, db_name=db_name)
+
+
+def db_revision(db_name=None, settings=None):
+    logger.debug("Getting DB revision...")
+    conn = db_connect(settings=settings, override_db_name=db_name)
     cursor = conn.cursor()
     cursor.execute("SELECT * FROM alembic_version")
     row = cursor.fetchone()
@@ -95,23 +113,23 @@ def db_revision(conn_params=None, settings=None, override_db_name=None):
     return row[0] if row else None
 
 
-def db_table_exists(table_name: str, conn_params=None, settings=None, override_db_name=None):
+def db_table_exists(table_name: str, db_name=None, settings=None) -> bool:
     logger.debug(f"Checking if DB table '{table_name}' exists")
-    conn = db_connect(conn_params=conn_params, settings=settings, override_db_name=override_db_name)
+    conn = db_connect(settings=settings, override_db_name=db_name)
     cursor = conn.cursor()
     cursor.execute(f"SELECT * FROM information_schema.tables WHERE table_name = '{table_name}'")
-    logger.debug("%r %r", cursor.rowcount, cursor.rowcount > 1)
-    return cursor.rowcount == 1
+    row = cursor.fetchone()
+    logger.debug("Row: %r", row)
+    return row[0] if row else None
 
 
-def create_db(conn_params=None, settings=None, drop=False):
-    if conn_params is None:
-        conn_params = db_connection_params(settings)
-    logger.debug("Connection params: %r", conn_params)
+def create_db(settings=None, drop=False):
+    actual_db_name = get_db_connection_param("POSTGRESQL_DATABASE", settings)
+    logger.debug("Actual DB name: %r", actual_db_name)
 
-    new_db_name = sql.Identifier(conn_params['dbname'])
+    new_db_name = sql.Identifier(actual_db_name)
 
-    con = db_connect(conn_params=conn_params, settings=settings, override_db_name='postgres')
+    con = db_connect(settings=settings, override_db_name='postgres')
     try:
         con.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         with con.cursor() as cur:
@@ -123,7 +141,7 @@ def create_db(conn_params=None, settings=None, drop=False):
                 cur.execute(
                     'SELECT count(*) FROM pg_catalog.pg_database '
                     'WHERE datname = %s',
-                    [conn_params['dbname']])
+                    [actual_db_name])
                 if not cur.fetchone()[0]:
                     cur.execute(sql.SQL('CREATE DATABASE {}').format(new_db_name))
     finally:
@@ -132,20 +150,17 @@ def create_db(conn_params=None, settings=None, drop=False):
     logger.debug('DB %s created.', new_db_name.string)
 
 
-def drop_db(conn_params=None, settings=None):
+def drop_db(settings=None):
     """Clear existing data and create new tables."""
-    if conn_params is None:
-        conn_params = db_connection_params(settings=settings)
-    logger.debug("Connection params: %r", conn_params)
+    actual_db_name = get_db_connection_param("POSTGRESQL_DATABASE", settings)
+    logger.debug("Actual DB name: %r", actual_db_name)
 
-    logger.debug('drop_db %s', conn_params)
-
-    con = db_connect(conn_params=conn_params, settings=settings, override_db_name='postgres')
+    con = db_connect(settings=settings, override_db_name='postgres')
     try:
         con.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         with con.cursor() as cur:
             cur.execute(
-                sql.SQL('DROP DATABASE IF EXISTS {}').format(sql.Identifier(conn_params['dbname'])))
-        logger.debug('database %s dropped', conn_params['dbname'])
+                sql.SQL('DROP DATABASE IF EXISTS {}').format(sql.Identifier(actual_db_name)))
+        logger.debug('database %s dropped', actual_db_name)
     finally:
         con.close()

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+Single-database configuration for Flask.

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,0 +1,50 @@
+# A generic, single database configuration.
+
+[alembic]
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic,flask_migrate
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[logger_flask_migrate]
+level = INFO
+handlers =
+qualname = flask_migrate
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -20,7 +20,7 @@ keys = console
 keys = generic
 
 [logger_root]
-level = WARN
+level = INFO
 handlers = console
 qualname =
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,91 @@
+from __future__ import with_statement
+
+import logging
+from logging.config import fileConfig
+
+from flask import current_app
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+logger = logging.getLogger('alembic.env')
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+config.set_main_option(
+    'sqlalchemy.url',
+    str(current_app.extensions['migrate'].db.get_engine().url).replace(
+        '%', '%%'))
+target_metadata = current_app.extensions['migrate'].db.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+
+    # this callback is used to prevent an auto-migration from being generated
+    # when there are no changes to the schema
+    # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
+    def process_revision_directives(context, revision, directives):
+        if getattr(config.cmd_opts, 'autogenerate', False):
+            script = directives[0]
+            if script.upgrade_ops.is_empty():
+                directives[:] = []
+                logger.info('No changes in schema detected.')
+
+    connectable = current_app.extensions['migrate'].db.get_engine()
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            process_revision_directives=process_revision_directives,
+            **current_app.extensions['migrate'].configure_args
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/8b2e530dc029_initial_revision.py
+++ b/migrations/versions/8b2e530dc029_initial_revision.py
@@ -1,0 +1,21 @@
+"""Initial revision
+
+Revision ID: 8b2e530dc029
+Revises: 
+Create Date: 2021-08-31 14:29:46.095169
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '8b2e530dc029'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/migrations/versions/8b2e530dc029_initial_revision.py
+++ b/migrations/versions/8b2e530dc029_initial_revision.py
@@ -1,7 +1,7 @@
 """Initial revision
 
 Revision ID: 8b2e530dc029
-Revises: 
+Revises:
 Create Date: 2021-08-31 14:29:46.095169
 
 """

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ flask-restful==0.3.8
 flask-login~=0.5.0
 flask-shell-ipython==0.4.1
 Flask-SQLAlchemy==2.5.1
+Flask-Migrate==3.1.0
 flask-wtf~=0.15.1
 Flask==2.0.0
 gunicorn~=20.1.0

--- a/tests/conftest_helpers.py
+++ b/tests/conftest_helpers.py
@@ -107,10 +107,8 @@ def app_context(request_settings,
                 init_db=True, clean_db=True, drop_db=False):
     try:
         os.environ.pop("FLASK_APP_CONFIG_FILE", None)
-        conn_param = lm_db.db_connection_params(request_settings)
         if init_db:
-            lm_db.create_db(conn_params=conn_param)
-            logger.debug("DB created (conn params=%r)", conn_param)
+            lm_db.create_db(settings=request_settings)
         flask_app = create_app(env="testing", settings=request_settings, init_app=False)
         flask_app.before_request(process_auto_login)
         with flask_app.app_context() as ctx:
@@ -130,8 +128,7 @@ def app_context(request_settings,
             if drop_db:
                 lm_db.db.close_all_sessions()
                 lm_db.db.engine.pool.dispose()
-                lm_db.drop_db(conn_param)
-                logger.debug("DB deleted (connection params=%r)", conn_param)
+                lm_db.drop_db(settings=request_settings)
     except Exception as e:
         logger.exception(e)
         raise RuntimeError(e)


### PR DESCRIPTION
This PR allows to programmatically manage database migrations:
* a CLI interface (exposed through the `db` command) allows to list, create, apply migrations
* new migrations will be automatically applied during the initialisation process.