### PR TITLE
Fix/unavailable rocrate

### DIFF
--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -308,6 +308,9 @@ def workflows_post(body, _registry=None, _submitter_id=None):
     except KeyError as e:
         return lm_exceptions.report_problem(400, "Bad Request", extra_info={"exception": str(e)},
                                             detail=messages.input_data_missing)
+    except lm_exceptions.DownloadROCrateException as e:
+        return lm_exceptions.report_problem(400, "Bad Request", extra_info={"exception": str(e)},
+                                            detail=messages.invalid_ro_crate)
     except lm_exceptions.NotValidROCrateException as e:
         return lm_exceptions.report_problem(400, "Bad Request", extra_info={"exception": str(e)},
                                             detail=messages.invalid_ro_crate)

--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -308,7 +308,7 @@ def workflows_post(body, _registry=None, _submitter_id=None):
     except KeyError as e:
         return lm_exceptions.report_problem(400, "Bad Request", extra_info={"exception": str(e)},
                                             detail=messages.input_data_missing)
-    except lm_exceptions.DownloadROCrateException as e:
+    except lm_exceptions.DownloadException as e:
         return lm_exceptions.report_problem(400, "Bad Request", extra_info={"exception": str(e)},
                                             detail=messages.invalid_ro_crate)
     except lm_exceptions.NotValidROCrateException as e:

--- a/lifemonitor/api/models/rocrate.py
+++ b/lifemonitor/api/models/rocrate.py
@@ -115,8 +115,8 @@ class ROCrate(Resource):
 
     def download(self, target_path: str) -> str:
         # report if the workflow is not longer available on the origin server
-        if self._metadata and not check_resource_exists(self.uri):
-            raise lm_exceptions.DownloadException(details=f"Workflow not found on the origin: {self.uri}", status=410)
+        if self._metadata and not self.available:
+            raise lm_exceptions.DownloadException(detail=f"Workflow not found on the origin: {self.uri}", status=410)
 
         errors = []
         # try either with authorization header and without authorization

--- a/lifemonitor/api/models/rocrate.py
+++ b/lifemonitor/api/models/rocrate.py
@@ -116,7 +116,7 @@ class ROCrate(Resource):
     def download(self, target_path: str) -> str:
         # report if the workflow is not longer available on the origin server
         if self._metadata and not check_resource_exists(self.uri):
-            raise lm_exceptions.DownloadException(detail=f"Workflow not found on the origin: {self.uri}", status=410)
+            raise lm_exceptions.DownloadException(detail=f"Not found: {self.uri}", status=410)
 
         errors = []
         # try either with authorization header and without authorization

--- a/lifemonitor/api/models/rocrate.py
+++ b/lifemonitor/api/models/rocrate.py
@@ -115,7 +115,7 @@ class ROCrate(Resource):
 
     def download(self, target_path: str) -> str:
         # report if the workflow is not longer available on the origin server
-        if self._metadata and not self.available:
+        if self._metadata and not check_resource_exists(self.uri):
             raise lm_exceptions.DownloadException(detail=f"Workflow not found on the origin: {self.uri}", status=410)
 
         errors = []

--- a/lifemonitor/api/models/rocrate.py
+++ b/lifemonitor/api/models/rocrate.py
@@ -65,7 +65,7 @@ class ROCrate(Resource):
 
     @hybrid_property
     def crate_metadata(self):
-        if not self._metadata_loaded:
+        if not self._metadata_loaded and not self._metadata:
             self.load_metadata()
         return self._metadata
 

--- a/lifemonitor/exceptions.py
+++ b/lifemonitor/exceptions.py
@@ -133,6 +133,14 @@ class WorkflowVersionConflictException(LifeMonitorException):
             detail=detail, status=409, **kwargs)
 
 
+class DownloadROCrateException(LifeMonitorException):
+
+    def __init__(self, detail="Unable to get RO-Crate for workflow",
+                 type="about:blank", status=500, instance=None, **kwargs):
+        super().__init__(title="Internal Server Error",
+                         detail=detail, status=status, **kwargs)
+
+
 class NotValidROCrateException(LifeMonitorException):
 
     def __init__(self, detail="Not valid RO Crate",

--- a/lifemonitor/exceptions.py
+++ b/lifemonitor/exceptions.py
@@ -133,7 +133,7 @@ class WorkflowVersionConflictException(LifeMonitorException):
             detail=detail, status=409, **kwargs)
 
 
-class DownloadROCrateException(LifeMonitorException):
+class DownloadException(LifeMonitorException):
 
     def __init__(self, detail="Unable to get RO-Crate for workflow",
                  type="about:blank", status=500, instance=None, **kwargs):

--- a/lifemonitor/exceptions.py
+++ b/lifemonitor/exceptions.py
@@ -135,9 +135,9 @@ class WorkflowVersionConflictException(LifeMonitorException):
 
 class DownloadException(LifeMonitorException):
 
-    def __init__(self, detail="Unable to get RO-Crate for workflow",
+    def __init__(self, detail=None,
                  type="about:blank", status=500, instance=None, **kwargs):
-        super().__init__(title="Internal Server Error",
+        super().__init__(title="Download error",
                          detail=detail, status=status, **kwargs)
 
 

--- a/lifemonitor/utils.py
+++ b/lifemonitor/utils.py
@@ -153,7 +153,7 @@ def _download_from_remote(url, output_stream, authorization=None):
 
 def check_resource_exists(url):
     r = requests.head(url, verify=False)
-    result = r.status_code != 404
+    result = r.status_code == 200
     logger.debug("Checking if resource %s exists: %r", url, result)
     return result
 

--- a/lifemonitor/utils.py
+++ b/lifemonitor/utils.py
@@ -33,7 +33,6 @@ import tempfile
 import urllib
 import uuid
 import zipfile
-import requests
 from importlib import import_module
 from os.path import basename, dirname, isfile, join
 

--- a/lifemonitor/utils.py
+++ b/lifemonitor/utils.py
@@ -33,6 +33,7 @@ import tempfile
 import urllib
 import uuid
 import zipfile
+import requests
 from importlib import import_module
 from os.path import basename, dirname, isfile, join
 
@@ -166,12 +167,12 @@ def download_url(url: str, target_path: str = None, authorization: str = None) -
             logger.info("Fetched %s of data from %s",
                         sizeof_fmt(os.path.getsize(target_path)),
                         url)
-    except (urllib.error.URLError, requests.exceptions.HTTPError) as e:
+    except (urllib.error.URLError, IOError) as e:
         # requests raised on an exception as we were trying to download.
         raise \
-            lm_exceptions.NotValidROCrateException(
+            lm_exceptions.DownloadROCrateException(
                 details=f"Error downloading RO-crate from {url}",
-                status=400,
+                status=500,
                 original_error=str(e))
     return target_path
 

--- a/lifemonitor/utils.py
+++ b/lifemonitor/utils.py
@@ -177,14 +177,14 @@ def download_url(url: str, target_path: str = None, authorization: str = None) -
         logger.exception(e)
         raise \
             lm_exceptions.DownloadException(
-                details=f"Error downloading from {url}",
+                detail=f"Error downloading from {url}",
                 status=400,
                 original_error=str(e))
     except requests.exceptions.HTTPError as e:
         logger.exception(e)
         raise \
             lm_exceptions.DownloadException(
-                details=f"Error downloading from {url}",
+                detail=f"Error downloading from {url}",
                 status=e.response.status_code,
                 original_error=str(e))
     except IOError as e:
@@ -192,7 +192,7 @@ def download_url(url: str, target_path: str = None, authorization: str = None) -
         logger.exception(e)
         raise \
             lm_exceptions.DownloadException(
-                details=f"Error downloading from {url}",
+                detail=f"Error downloading from {url}",
                 status=500,
                 original_error=str(e))
     return target_path

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -666,6 +666,8 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /workflows/{wf_uuid}/suites:
     get:

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -1160,6 +1160,13 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
 
+    InternalServerError:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+
     WorkflowRegistered:
       description: A new workflow has been registered.
       content:

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -610,7 +610,6 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
-
   /workflows/{wf_uuid}/rocrate/{wf_version}/metadata:
     get:
       x-openapi-router-controller: lifemonitor.api.controllers
@@ -630,7 +629,7 @@ paths:
         "200":
           description: |
             RO-Crate JSON metadata for the specified workflow and workflow version.
-            RO-Crate specifcation is available at https://www.researchobject.org/ro-crate/.          
+            RO-Crate specifcation is available at https://www.researchobject.org/ro-crate/.
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -1512,16 +1511,19 @@ components:
                   {
                     uuid: "21ac72ec-b9a5-49e0-b5a6-1322b8b54552",
                     version: "0.1",
-                    links: {
-                      origin: "http://webserver:5000/download?file=ro-crate-galaxy-sortchangecase.crate.zip"
-                    },
-                    ro_crate: {
-                      links: {
-                        "download": "https://lm:8000/workflows/123e4567-e89b-12d3-a456-426614174000/rocrate/1.0/download",
-                        "metadata": "https://lm:8000/workflows/123e4567-e89b-12d3-a456-426614174000/rocrate/1.0/metadata",
-                        "origin": "http://webserver:5000/download?file=ro-crate-galaxy-sortchangecase.crate.zip"
-                      }
-                    },
+                    links:
+                      {
+                        origin: "http://webserver:5000/download?file=ro-crate-galaxy-sortchangecase.crate.zip",
+                      },
+                    ro_crate:
+                      {
+                        links:
+                          {
+                            "download": "https://lm:8000/workflows/123e4567-e89b-12d3-a456-426614174000/rocrate/1.0/download",
+                            "metadata": "https://lm:8000/workflows/123e4567-e89b-12d3-a456-426614174000/rocrate/1.0/metadata",
+                            "origin": "http://webserver:5000/download?file=ro-crate-galaxy-sortchangecase.crate.zip",
+                          },
+                      },
                     submitter: { id: 501, username: "lm" },
                   },
                 ]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -29,6 +29,6 @@ import lifemonitor.utils as utils
 
 def test_download_url_404():
     with tempfile.TemporaryDirectory() as d:
-        with pytest.raises(lm_exceptions.DownloadROCrateException) as excinfo:
+        with pytest.raises(lm_exceptions.DownloadException) as excinfo:
             _ = utils.download_url('http://httpbin.org/status/404', os.path.join(d, 'get_404'))
         assert excinfo.value.status == 400

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -31,4 +31,4 @@ def test_download_url_404():
     with tempfile.TemporaryDirectory() as d:
         with pytest.raises(lm_exceptions.DownloadException) as excinfo:
             _ = utils.download_url('http://httpbin.org/status/404', os.path.join(d, 'get_404'))
-        assert excinfo.value.status == 400
+        assert excinfo.value.status == 404

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -29,6 +29,6 @@ import lifemonitor.utils as utils
 
 def test_download_url_404():
     with tempfile.TemporaryDirectory() as d:
-        with pytest.raises(lm_exceptions.NotValidROCrateException) as excinfo:
+        with pytest.raises(lm_exceptions.DownloadROCrateException) as excinfo:
             _ = utils.download_url('http://httpbin.org/status/404', os.path.join(d, 'get_404'))
         assert excinfo.value.status == 400


### PR DESCRIPTION
This PR addresses issues  #142 and (partially) https://github.com/crs4/lifemonitor-web/issues/4

Workflows registered on LifeMonitor are always available for monitoring even if they have been deleted from the source. Also RO-Crate metadata are still available, while an appropriate error message is reported when a client tries to download the RO-Crate archive.