### PR TITLE
Set exec permissions on seek image entrypoint

### DIFF
--- a/tests/config/registries/seek/seek.Dockerfile
+++ b/tests/config/registries/seek/seek.Dockerfile
@@ -8,7 +8,8 @@ COPY entrypoint.sh /usr/local/bin
 RUN cd /tmp && tar xzvf data.tar.gz \
     && chown -R www-data:www-data data \
     && mv data /seek/ \
-    && rm -rf data.tar.gz
+    && rm -rf data.tar.gz \
+    && chmod 755 /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 


### PR DESCRIPTION
The seek image used for testing should be executable by any user id.  This PR sets the entrypoint permissions to 755.  It seems this is sufficient to let any user start it.