### PR TITLE
Fix/missing workflow name

### DIFF
--- a/lifemonitor/api/models/rocrate.py
+++ b/lifemonitor/api/models/rocrate.py
@@ -84,6 +84,10 @@ class ROCrate(Resource):
         return self._roc_helper.name
 
     @property
+    def main_entity_name(self):
+        return self._roc_helper.mainEntity['name']
+
+    @property
     def _roc_helper(self):
         if not self.__roc_helper:
             if not self._metadata_loaded:

--- a/lifemonitor/api/models/workflows.py
+++ b/lifemonitor/api/models/workflows.py
@@ -238,6 +238,10 @@ class WorkflowVersion(ROCrate):
         return self.uri
 
     @property
+    def workflow_name(self) -> str:
+        return self.name or self.main_entity_name or self.dataset_name
+
+    @property
     def is_latest(self) -> bool:
         return self.workflow.latest_version.version == self.version
 

--- a/lifemonitor/api/services.py
+++ b/lifemonitor/api/services.py
@@ -136,7 +136,12 @@ class LifeMonitor:
         if authorization:
             auth = ExternalServiceAuthorizationHeader(workflow_submitter, header=authorization)
             auth.resources.append(wv)
+
         if name is None:
+            if wv.workflow_name is None:
+                raise lm_exceptions.LifeMonitorException(title="Missing attribute 'name'",
+                                                         detail="Attribute 'name' is not defined and it cannot be retrieved ' \
+                                                         'from the workflow RO-Crate (name of 'mainEntity' and '/' dataset not set)",
                                                          status=400)
             w.name = wv.workflow_name
             wv.name = wv.workflow_name

--- a/lifemonitor/api/services.py
+++ b/lifemonitor/api/services.py
@@ -137,8 +137,9 @@ class LifeMonitor:
             auth = ExternalServiceAuthorizationHeader(workflow_submitter, header=authorization)
             auth.resources.append(wv)
         if name is None:
-            w.name = wv.dataset_name
-            wv.name = wv.dataset_name
+                                                         status=400)
+            w.name = wv.workflow_name
+            wv.name = wv.workflow_name
 
         # set workflow visibility
         w.public = public

--- a/migrations/versions/861eca55901d_fix_workflows_with_no_name.py
+++ b/migrations/versions/861eca55901d_fix_workflows_with_no_name.py
@@ -1,0 +1,24 @@
+"""Fix workflows with no name
+
+Revision ID: 861eca55901d
+Revises: 01684f92a380
+Create Date: 2021-10-30 15:51:52.296778
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '861eca55901d'
+down_revision = '01684f92a380'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    bind.execute("update resource set name='unknown' where id in (select id from workflow natural join resource where name='')")
+
+
+def downgrade():
+    pass

--- a/tests/config/data/make-test-rocrates.py
+++ b/tests/config/data/make-test-rocrates.py
@@ -49,6 +49,7 @@ test_crates.append(('ro-crate-galaxy-sortchangecase', 'ro-crate-galaxy-sortchang
 test_crates.append(('ro-crate-galaxy-sortchangecase', 'ro-crate-galaxy-sortchangecase-invalid-service-type'))
 test_crates.append(('ro-crate-galaxy-sortchangecase', 'ro-crate-galaxy-sortchangecase-invalid-service-url'))
 test_crates.append(('ro-crate-galaxy-sortchangecase', 'ro-crate-galaxy-sortchangecase-github-actions'))
+test_crates.append(('ro-crate-galaxy-sortchangecase', 'ro-crate-galaxy-sortchangecase-no-name'))
 
 # clean up RO-Crates folder
 if os.path.exists(crates_target_path):
@@ -166,6 +167,17 @@ patch_metadata_graph_node('crates/ro-crate-galaxy-sortchangecase-github-actions/
                               "@id": "https://w3id.org/ro/terms/test#GithubService",
                               "name": "Github",
                               "url": {"@id": "https://github.com"}
+                          })
+
+patch_metadata_graph_node('crates/ro-crate-galaxy-sortchangecase-no-name/ro-crate-metadata.json',
+                          node=("@type", "Dataset"),
+                          properties={
+                              'name': None
+                          })
+patch_metadata_graph_node('crates/ro-crate-galaxy-sortchangecase-no-name/ro-crate-metadata.json',
+                          node=("@id", "sort-and-change-case.ga"),
+                          properties={
+                              'name': None
                           })
 
 # create zip archives

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,7 +248,19 @@ def generic_workflow(app_client):
         'uuid': str(uuid.uuid4()),
         'version': '1',
         'roc_link': "http://webserver:5000/download?file=ro-crate-galaxy-sortchangecase.crate.zip",
-        'name': 'Galaxy workflow from Generic Link',
+        'name': 'sort-and-change-case',
+        'testing_service_type': 'jenkins',
+        'authorization': app_client.application.config['WEB_SERVER_AUTH_TOKEN']
+    }
+
+
+@pytest.fixture
+def workflow_no_name(app_client):
+    return {
+        'uuid': str(uuid.uuid4()),
+        'version': '1',
+        'roc_link': "http://webserver:5000/download?file=ro-crate-galaxy-sortchangecase-no-name.crate.zip",
+        'name': 'Galaxy workflow from Generic Link (no name)',
         'testing_service_type': 'jenkins',
         'authorization': app_client.application.config['WEB_SERVER_AUTH_TOKEN']
     }

--- a/tests/integration/api/controllers/test_users.py
+++ b/tests/integration/api/controllers/test_users.py
@@ -159,6 +159,64 @@ def test_generic_workflow_registration_wo_uuid(app_client, client_auth_method,
     ClientAuthenticationMethod.API_KEY,
     ClientAuthenticationMethod.AUTHORIZATION_CODE,
 ], indirect=True)
+def test_generic_workflow_registration_no_name_exception(app_client, client_auth_method,
+                                                         user1, user1_auth, client_credentials_registry, workflow_no_name):
+    logger.debug("User: %r", user1)
+    logger.debug("headers: %r", user1_auth)
+    workflow = workflow_no_name
+    logger.debug("Selected workflow: %r", workflow)
+    logger.debug("Using oauth2 user: %r", user1)
+    # prepare body
+    body = {'roc_link': workflow['roc_link'],
+            'version': workflow['version'],
+            'authorization': workflow['authorization']}
+    logger.debug("The BODY: %r", body)
+    response = app_client.post('/users/current/workflows', json=body, headers=user1_auth)
+    logger.debug("The actual response: %r", response.data)
+
+    utils.assert_status_code(400, response.status_code)
+    data = json.loads(response.data)
+    logger.debug("Response data: %r", data)
+    assert data['title'] == 'Missing attribute \'name\'', "Unexpected error"
+
+
+@pytest.mark.parametrize("client_auth_method", [
+    ClientAuthenticationMethod.API_KEY,
+    ClientAuthenticationMethod.AUTHORIZATION_CODE,
+], indirect=True)
+def test_generic_workflow_registration_no_name(app_client, client_auth_method,
+                                               user1, user1_auth, client_credentials_registry, generic_workflow):
+    logger.debug("User: %r", user1)
+    logger.debug("headers: %r", user1_auth)
+    workflow = generic_workflow
+    logger.debug("Selected workflow: %r", workflow)
+    logger.debug("Using oauth2 user: %r", user1)
+    # prepare body
+    body = {'roc_link': workflow['roc_link'],
+            'version': workflow['version'],
+            'authorization': workflow['authorization']}
+    logger.debug("The BODY: %r", body)
+    response = app_client.post('/users/current/workflows', json=body, headers=user1_auth)
+    logger.debug("The actual response: %r", response.data)
+    utils.assert_status_code(201, response.status_code)
+    data = json.loads(response.data)
+    logger.debug("Response data: %r", data)
+    assert data['wf_version'] == workflow['version'], \
+        "Response should be equal to the workflow UUID"
+    assert data['uuid'], "Workflow UUID was not generated or returned"
+
+    response = app_client.get(f'/workflows/{data["uuid"]}', headers=user1_auth)
+    logger.debug("The actual response: %r", response.data)
+    utils.assert_status_code(200, response.status_code)
+    data = json.loads(response.data)
+    logger.debug("Response data: %r", data)
+    assert data['name'] == workflow['name'], "Unexpected workflow name"
+
+
+@pytest.mark.parametrize("client_auth_method", [
+    ClientAuthenticationMethod.API_KEY,
+    ClientAuthenticationMethod.AUTHORIZATION_CODE,
+], indirect=True)
 def test_registry_workflow_registration(app_client, client_auth_method,
                                         user1, user1_auth, client_credentials_registry, valid_workflow):
     logger.debug("User: %r", user1)


### PR DESCRIPTION
This PR addresses issue #164.

When a client submits a workflow with no `name` as parameter, the service will try to use the `name` of the RO-Crate `mainEntity` as workflow name.
If no name can be found, a proper error will be reported to the client and the workflow will not be registered.