### PR TITLE
Bump ro-crate-py version

### DIFF
--- a/interaction_experiments/check_galaxy.py
+++ b/interaction_experiments/check_galaxy.py
@@ -31,7 +31,6 @@ import tempfile
 from rocrate.rocrate import ROCrate
 
 
-GALAXY_IMG = "bgruening/galaxy-stable:20.09"
 PLANEMO_ENTITY = "https://w3id.org/ro/terms/test#PlanemoEngine"
 
 
@@ -67,8 +66,7 @@ def check_workflow(crate, crate_dir):
     new_workflow_path = def_path.parent / workflow_path.name
     # Planemo expects the test file in the same dir as the workflow
     shutil.copy2(workflow_path, new_workflow_path)
-    cmd = ["planemo", "test", "--engine", "docker_galaxy",
-           "--docker_galaxy_image", GALAXY_IMG, new_workflow_path]
+    cmd = ["planemo", "test", "--biocontainers", str(new_workflow_path)]
     print("Running Planemo (this may take a while)")
     p = subprocess.run(cmd)
     p.check_returncode()

--- a/interaction_experiments/data/crates/ro-crate-cwl-basefreqsum/ro-crate-metadata.json
+++ b/interaction_experiments/data/crates/ro-crate-cwl-basefreqsum/ro-crate-metadata.json
@@ -24,9 +24,14 @@
             "about": {
                 "@id": "./"
             },
-            "conformsTo": {
-                "@id": "https://w3id.org/ro/crate/1.1"
-            }
+            "conformsTo": [
+                {
+                    "@id": "https://w3id.org/ro/crate/1.1"
+                },
+                {
+                    "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"
+                }
+            ]
         },
         {
             "@id": "./",
@@ -102,7 +107,9 @@
         },
         {
             "@id": "README.md",
-            "@type": "File"
+            "@type": "File",
+            "about": "./",
+            "encodingFormat": "text/markdown"
         },
         {
             "@id": "#cwl",

--- a/interaction_experiments/data/crates/ro-crate-galaxy-sortchangecase/ro-crate-metadata.json
+++ b/interaction_experiments/data/crates/ro-crate-galaxy-sortchangecase/ro-crate-metadata.json
@@ -24,9 +24,14 @@
             "about": {
                 "@id": "./"
             },
-            "conformsTo": {
-                "@id": "https://w3id.org/ro/crate/1.1"
-            }
+            "conformsTo": [
+                {
+                    "@id": "https://w3id.org/ro/crate/1.1"
+                },
+                {
+                    "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"
+                }
+            ]
         },
         {
             "@id": "./",
@@ -82,7 +87,9 @@
         },
         {
             "@id": "README.md",
-            "@type": "File"
+            "@type": "File",
+            "about": "./",
+            "encodingFormat": "text/markdown"
         },
         {
             "@id": "#galaxy",

--- a/interaction_experiments/requirements.txt
+++ b/interaction_experiments/requirements.txt
@@ -1,2 +1,2 @@
-planemo==0.74.2
-rocrate~=0.4.0
+planemo~=0.74
+rocrate==0.5.2

--- a/interaction_experiments/workflow_examples/galaxy/sort-and-change-case/test_on_docker_galaxy.sh
+++ b/interaction_experiments/workflow_examples/galaxy/sort-and-change-case/test_on_docker_galaxy.sh
@@ -5,14 +5,10 @@ set -euo pipefail
 this="${BASH_SOURCE-$0}"
 this_dir=$(cd -P -- "$(dirname -- "${this}")" && pwd -P)
 
-# change these as needed
-GALAXY_IMG=bgruening/galaxy-stable:20.05
-
 pushd "${this_dir}"
 # looks for sort-and-change-case-test.yml in the same dir as
 # sort-and-change-case.ga
 planemo test \
-	--engine docker_galaxy \
-	--docker_galaxy_image "${GALAXY_IMG}" \
+	--biocontainers \
 	sort-and-change-case.ga
 popd

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,6 @@ PyYAML~=5.4.1
 pika~=1.2.0
 redis~=3.5.3
 requests~=2.26.0
-rocrate==0.5.1
+rocrate==0.5.2
 SQLAlchemy~=1.3.23
 wheel~=0.37.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,6 @@ PyYAML~=5.4.1
 pika~=1.2.0
 redis~=3.5.3
 requests~=2.26.0
-rocrate~=0.4.0
+rocrate==0.5.1
 SQLAlchemy~=1.3.23
 wheel~=0.37.0
-


### PR DESCRIPTION
Bumps ro-crate-py to 0.5.1, which contains [critical bug fixes](https://github.com/ResearchObject/ro-crate-py/pull/100) to support recent RO-Crates from WorkflowHub.