### PR TITLE
Update chart to 0.5.0

### DIFF
--- a/k8s/Chart.lock
+++ b/k8s/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 10.1.1
-digest: sha256:386060b432509d7925e2d620559d44d0efbe869184049da1fc12cfd86b0b5550
-generated: "2021-04-25T15:26:03.079993489Z"
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 15.3.2
+digest: sha256:e69b28d1eb2d1b5e7fef36eb02b99cf305f52af14e4d2bda033eaf7544ef498b
+generated: "2021-10-21T16:46:24.046062+02:00"

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/pvc-backend-data.yaml
+++ b/k8s/pvc-backend-data.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-api-workflows
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/templates/_helpers.tpl
+++ b/k8s/templates/_helpers.tpl
@@ -110,6 +110,9 @@ Define volumes shared by some pods.
 - name: lifemonitor-settings
   secret:
     secretName: {{ include "chart.fullname" . }}-settings
+- name: lifemonitor-data
+  persistentVolumeClaim:
+    claimName: data-{{- .Release.Name -}}-workflows
 {{- end -}}
 
 {{/*
@@ -122,4 +125,6 @@ Define mount points shared by some pods.
 - name: lifemonitor-settings
   mountPath: "/lm/settings.conf"
   subPath: settings.conf
+- name: lifemonitor-data
+  mountPath: "/var/data/lm"
 {{- end -}}

--- a/k8s/templates/job-init.yaml
+++ b/k8s/templates/job-init.yaml
@@ -3,7 +3,9 @@ kind: Job
 metadata:
   name: {{ include "chart.fullname" . }}-init
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "chart.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   template:
     spec:

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -107,6 +107,7 @@ lifemonitor:
 
   persistence:
     storageClass: *storageClass
+    storageSize: 8Gi
 
   # Enable/Disable the pod to test connection to the LifeMonitor back-end
   enableTestConnection: false


### PR DESCRIPTION
This PR introduces minor updates and bug fixes to support back-end v0.5.0:
* adds PVC to store workflows
* updates labels of the init job to fix an issue with `helm upgrade`