### PR TITLE
Feature/editing suite instance name

### DIFF
--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -667,6 +667,22 @@ def instances_get_by_id(instance_uuid):
 
 
 @authorized
+def instances_put(instance_uuid, body):
+    try:
+        instance = _get_instances_or_problem(instance_uuid)
+        if isinstance(instance, Response):
+            return instance
+        instance.name = body.get('name', instance.name)
+        instance.save()
+        clear_cache()
+        logger.debug("Instance %r updated", instance_uuid)
+        return connexion.NoContent, 204
+    except Exception as e:
+        return lm_exceptions.report_problem(500, "Internal Error", extra_info={"exception": str(e)},
+                                            detail=messages.unable_to_delete_suite.format(instance_uuid))
+
+
+@authorized
 def instances_delete_by_id(instance_uuid):
     try:
         response = _get_instances_or_problem(instance_uuid)

--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -574,6 +574,22 @@ def suites_post(wf_uuid, wf_version, body):
 
 
 @authorized
+def suites_put(suite_uuid, body):
+    try:
+        suite = _get_suite_or_problem(suite_uuid)
+        if isinstance(suite, Response):
+            return suite
+        suite.name = body.get('name', suite.name)
+        suite.save()
+        clear_cache()
+        logger.debug("Suite %r updated", suite_uuid)
+        return connexion.NoContent, 204
+    except Exception as e:
+        return lm_exceptions.report_problem(500, "Internal Error", extra_info={"exception": str(e)},
+                                            detail=messages.unable_to_delete_suite.format(suite_uuid))
+
+
+@authorized
 def suites_delete(suite_uuid):
     try:
         response = _get_suite_or_problem(suite_uuid)

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -1086,6 +1086,42 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+    put:
+      summary: Update a test suite
+      description: "Update basic information of the specified suite"
+      x-openapi-router-controller: lifemonitor.api.controllers
+      operationId: "suites_put"
+      tags: ["Test Suites"]
+      security:
+        - apiKey: ["workflow.write"]
+        - AuthorizationCodeFlow: ["workflow.write"]
+        - RegistryClientCredentials: ["workflow.write"]
+        - RegistryCodeFlow: ["workflow.write"]
+      parameters:
+        - $ref: "#/components/parameters/suite_uuid"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: A name for the test suite.
+                  example: Workflow Test Suite
+      responses:
+        "204":
+          description: "Suite updated"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /suites/{suite_uuid}/status:
     get:
       summary: "Get test suite status"

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -1263,6 +1263,42 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+    put:
+      summary: Update a test instance
+      description: "Update basic information of the specified test instance"
+      x-openapi-router-controller: lifemonitor.api.controllers
+      operationId: "instances_put"
+      tags: ["Test Instances"]
+      security:
+        - apiKey: ["workflow.write"]
+        - AuthorizationCodeFlow: ["workflow.write"]
+        - RegistryClientCredentials: ["workflow.write"]
+        - RegistryCodeFlow: ["workflow.write"]
+      parameters:
+        - $ref: "#/components/parameters/instance_uuid"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: A name for the test instance.
+                  example: Workflow Test Instance
+      responses:
+        "204":
+          description: "Test instance updated"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
     delete:
       x-openapi-router-controller: lifemonitor.api.controllers
       operationId: "instances_delete_by_id"


### PR DESCRIPTION
This PR extends the API with new PUT methods to allow editing of suite and instance names (see issue #195)