### PR TITLE
Feature/Admin CLI enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ instance
 **/node_modules
 data
 lifemonitor/static/dist
+lifemonitor/static/src/node_modules
 docker-compose.yml
 utils/certs/data
 tests/config/data/crates/*.zip

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -52,7 +52,7 @@ services:
     entrypoint: /bin/bash
     restart: "no"
     command: |
-      -c "wait-for-postgres.sh && flask init db"
+      -c "wait-for-postgres.sh && ./manage.py db init"
     depends_on:
       - "db"
     env_file: *env_file

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,7 +10,7 @@ services:
     restart: "no"
     entrypoint: /bin/bash
     command: |
-      -c "wait-for-postgres.sh && flask init db && /usr/local/bin/lm_entrypoint.sh"
+      -c "wait-for-postgres.sh && ./manage.py db init && /usr/local/bin/lm_entrypoint.sh"
     environment:
       - "FLASK_ENV=testingSupport"
       - "HOME=/lm"

--- a/docker/lifemonitor.Dockerfile
+++ b/docker/lifemonitor.Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9-buster as base
 # Install base requirements
 RUN apt-get update -q \
  && apt-get install -y --no-install-recommends \
-        bash \
+        bash lftp \
         redis-tools \
         postgresql-client-11 \
  && apt-get clean -y && rm -rf /var/lib/apt/lists

--- a/docker/lifemonitor.Dockerfile
+++ b/docker/lifemonitor.Dockerfile
@@ -60,7 +60,7 @@ RUN mkdir -p /var/data/lm \
 USER lm
 
 # Copy lifemonitor app
-COPY --chown=lm:lm app.py gunicorn.conf.py /lm/
+COPY --chown=lm:lm app.py manage.py gunicorn.conf.py /lm/
 COPY --chown=lm:lm specs /lm/specs
 COPY --chown=lm:lm lifemonitor /lm/lifemonitor
 COPY --chown=lm:lm migrations /lm/migrations

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -12,7 +12,7 @@ version: 0.7.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.7.1
+appVersion: 0.7.2
 
 # Chart dependencies
 dependencies:

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/pvc-backend-backup.yaml
+++ b/k8s/pvc-backend-backup.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-api-backup
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/templates/_helpers.tpl
+++ b/k8s/templates/_helpers.tpl
@@ -132,3 +132,16 @@ Define mount points shared by some pods.
 - name: lifemonitor-data
   mountPath: "/var/data/lm"
 {{- end -}}
+
+
+{{/*
+Define command to mirror (cluster) local backup to a remote site via SFTP
+*/}}
+{{- define "backup.remote.command" -}}
+{{- if and .Values.backup.remote .Values.backup.remote.enabled }}
+{{- printf "lftp -c \"open -u %s,%s sftp://%s; mirror -e /var/data/backup %s \"" 
+    .Values.backup.remote.user .Values.backup.remote.password 
+    .Values.backup.remote.host .Values.backup.remote.path
+}}
+{{- end }}
+{{- end }}

--- a/k8s/templates/backend-deployment.yaml
+++ b/k8s/templates/backend-deployment.yaml
@@ -38,7 +38,7 @@ spec:
           image: {{ include "chart.lifemonitor.image" . }}
           imagePullPolicy: {{ .Values.lifemonitor.imagePullPolicy }}
           command: ["/bin/sh","-c"]
-          args: ["wait-for-redis.sh && wait-for-postgres.sh && flask init wait-for-db"]
+          args: ["wait-for-redis.sh && wait-for-postgres.sh && ./manage.py db wait-for-db"]
           env:
           {{- include "lifemonitor.common-env" . | nindent 12 }}
           volumeMounts:

--- a/k8s/templates/job-backup.yaml
+++ b/k8s/templates/job-backup.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.backup.enabled -}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "chart.fullname" . }}-backup
+  labels:
+    app.kubernetes.io/name: {{ include "chart.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}  
+spec:
+  schedule: "{{ .Values.backup.schedule }}"
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: lifemonitor-backup
+            image: {{ include "chart.lifemonitor.image" . }}
+            imagePullPolicy: {{ .Values.lifemonitor.imagePullPolicy }}
+            command: ["/bin/sh","-c"]
+            args:        
+              - base_path="/var/data/backup" ;
+                db_backups_path="${base_path}/db" ;
+                crate_backups_path="${base_path}/crates" ;
+                mkdir -p ${db_backups_path} ;
+                mkdir -p ${crate_backups_path} ;
+                ./manage.py db backup -d ${db_backups_path} ;
+                find ${db_backups_path} -type f -mtime +60 -name '*.tar' -execdir rm -- '{}' \; ;
+                cp -urv /var/data/lm ${crate_backups_path} ;
+                {{ include "backup.remote.command" . }}
+            env:
+            {{- include "lifemonitor.common-env" . | nindent 12 }}
+            volumeMounts:
+            {{- include "lifemonitor.common-volume-mounts" . | nindent 12 }}
+            - name: lifemonitor-backup
+              mountPath: "/var/data/backup"
+          restartPolicy: OnFailure
+          volumes:
+            {{- include "lifemonitor.common-volume" . | nindent 10 }}
+          - name: lifemonitor-backup
+            persistentVolumeClaim:
+              claimName: {{ .Values.backup.existingClaim }}
+          {{- with .Values.lifemonitor.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.lifemonitor.affinity }}
+          affinity:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.lifemonitor.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 10 }}        
+          {{- end }}
+      backoffLimit: 4
+{{- end }}

--- a/k8s/templates/job-init.yaml
+++ b/k8s/templates/job-init.yaml
@@ -20,7 +20,7 @@ spec:
         image: {{ include "chart.lifemonitor.image" . }}
         imagePullPolicy: {{ .Values.lifemonitor.imagePullPolicy }}
         command: ["/bin/sh","-c"]
-        args: ["wait-for-redis.sh && wait-for-postgres.sh && flask init db && flask task-queue reset"]
+        args: ["wait-for-redis.sh && wait-for-postgres.sh && ./manage.py db initt db && flask task-queue reset"]
         env:
         {{- include "lifemonitor.common-env" . | nindent 10 }}
         volumeMounts:

--- a/k8s/templates/job-init.yaml
+++ b/k8s/templates/job-init.yaml
@@ -20,7 +20,7 @@ spec:
         image: {{ include "chart.lifemonitor.image" . }}
         imagePullPolicy: {{ .Values.lifemonitor.imagePullPolicy }}
         command: ["/bin/sh","-c"]
-        args: ["wait-for-redis.sh && wait-for-postgres.sh && ./manage.py db init db && ./manage.py task-queue reset"]
+        args: ["wait-for-redis.sh && wait-for-postgres.sh && ./manage.py db init && ./manage.py task-queue reset"]
         env:
         {{- include "lifemonitor.common-env" . | nindent 10 }}
         volumeMounts:

--- a/k8s/templates/job-init.yaml
+++ b/k8s/templates/job-init.yaml
@@ -20,7 +20,7 @@ spec:
         image: {{ include "chart.lifemonitor.image" . }}
         imagePullPolicy: {{ .Values.lifemonitor.imagePullPolicy }}
         command: ["/bin/sh","-c"]
-        args: ["wait-for-redis.sh && wait-for-postgres.sh && ./manage.py db initt db && flask task-queue reset"]
+        args: ["wait-for-redis.sh && wait-for-postgres.sh && ./manage.py db init db && ./manage.py task-queue reset"]
         env:
         {{- include "lifemonitor.common-env" . | nindent 10 }}
         volumeMounts:

--- a/k8s/templates/worker-deployment.yaml
+++ b/k8s/templates/worker-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           image: {{ include "chart.lifemonitor.image" . }}
           imagePullPolicy: {{ .Values.lifemonitor.imagePullPolicy }}
           command: ["/bin/sh","-c"]
-          args: ["wait-for-redis.sh && wait-for-postgres.sh && flask init wait-for-db"]
+          args: ["wait-for-redis.sh && wait-for-postgres.sh && ./manage.py db wait-for-db"]
           env:
           {{- include "lifemonitor.common-env" . | nindent 12 }}
           volumeMounts:

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -81,6 +81,22 @@ mail:
   ssl: true
   default_sender: ""
 
+# Backup settings
+backup:
+  enabled: false
+  schedule: "* 3 * * *"
+  successfulJobsHistoryLimit: 30
+  failedJobsHistoryLimit: 30
+  existingClaim: data-api-backup
+  # Settings to mirror the (cluster) local backup 
+  # to a remote site via SFTP
+  remote:
+    enabled: false
+    user: username
+    password: password
+    host: 10.0.1.135
+    path: /user/home/lm-backups
+
 lifemonitor:
   replicaCount: 1
 

--- a/lifemonitor/commands/api_key.py
+++ b/lifemonitor/commands/api_key.py
@@ -35,16 +35,16 @@ blueprint = Blueprint('api-key', __name__)
 
 
 @blueprint.cli.command('create')
-@click.argument("username")
-@click.option("--scope", "scope",  # type=click.Choice(ApiKey.SCOPES),
+@click.option("--scope", "scope",
               default="read", show_default=True)
 @click.option("--length", "length", default=40, type=int, show_default=True)
 @with_appcontext
-def api_key_create(username, scope="read", length=40):
+def api_key_create(scope="read", length=40):
     """
-    Create an API Key for a given user (identified by username)
+    Create an API Key for the 'admin' user
     """
-    logger.debug("Finding User '%s'...", username)
+    username = "admin"
+    logger.debug("Finding user '%s'...", username)
     user = User.find_by_username(username)
     if not user:
         print("User not found", file=sys.stderr)
@@ -52,25 +52,25 @@ def api_key_create(username, scope="read", length=40):
     logger.debug("User found: %r", user)
     api_key = generate_new_api_key(user, scope, length)
     print("%r" % api_key)
-    logger.debug("ApiKey created")
+    logger.debug("Api key created")
 
 
 @blueprint.cli.command('list')
-@click.argument("username")
 @with_appcontext
-def api_key_list(username):
+def api_key_list():
     """
-    Create an API Key for a given user (identified by username)
+    Create an API Key for the 'admin' user
     """
-    logger.debug("Finding User '%s'...", username)
+    username = "admin"
+    logger.debug("Finding user '%s'...", username)
     user = User.find_by_username(username)
     if not user:
         print("User not found", file=sys.stderr)
         sys.exit(99)
     logger.debug("User found: %r", user)
-    logger.info('-' * 82)
-    logger.info("User '%s' ApiKeys", user.username)
-    logger.info('-' * 82)
+    print('-' * 82)
+    print("Api keys of user '%s'" % user.username)
+    print('-' * 82)
     for key in user.api_keys:
         print(key)
 
@@ -80,27 +80,27 @@ def api_key_list(username):
 @with_appcontext
 def api_key_delete(api_key):
     """
-    Create an API Key for a given user (identified by username)
+    Create an API Key for the 'admin' user
     """
-    logger.debug("Finding ApiKey '%s'...", api_key)
+    logger.debug("Finding Api key '%s'...", api_key)
     key = ApiKey.find(api_key)
     if not key:
-        print("ApiKey not found", file=sys.stderr)
+        print("Api key not found", file=sys.stderr)
         sys.exit(99)
-    logger.debug("ApiKey found: %r", key)
+    logger.debug("Api key found: %r", key)
     key.delete()
-    print("ApiKey '%s' deleted!" % api_key)
-    logger.debug("ApiKey created")
+    print("Api key '%s' deleted!" % api_key)
+    logger.debug("Api key created")
 
 
 @blueprint.cli.command('clean')
-@click.argument("username")
 @with_appcontext
-def api_key_clean(username):
+def api_key_clean():
     """
-    Create an API Key for a given user (identified by username)
+    Create an API Key for the 'admin' user
     """
-    logger.debug("Finding User '%s'...", username)
+    username = "admin"
+    logger.debug("Finding user '%s'...", username)
     user = User.find_by_username(username)
     if not user:
         print("User not found", file=sys.stderr)
@@ -109,7 +109,7 @@ def api_key_clean(username):
     count = 0
     for key in user.api_keys:
         key.delete()
-        print("ApiKey '%s' deleted!" % key.key)
+        print("Api key '%s' deleted!" % key.key)
         count += 1
     print("%d ApiKeys deleted!" % count, file=sys.stderr)
-    logger.debug("ApiKeys of User '%s' deleted!", user.username)
+    logger.debug("ApiKeys of user '%s' deleted!", user.username)

--- a/lifemonitor/commands/api_key.py
+++ b/lifemonitor/commands/api_key.py
@@ -33,6 +33,9 @@ logger = logging.getLogger(__name__)
 # define the blueprint for DB commands
 blueprint = Blueprint('api-key', __name__)
 
+# set CLI help
+blueprint.cli.help = "Manage admin API keys"
+
 
 @blueprint.cli.command('create')
 @click.option("--scope", "scope",

--- a/lifemonitor/commands/cache.py
+++ b/lifemonitor/commands/cache.py
@@ -32,6 +32,7 @@ blueprint = Blueprint('cache', __name__)
 # set help for the CLI command
 blueprint.cli.help = "Manage cache"
 
+
 @blueprint.cli.command('clear')
 @with_appcontext
 def clear():

--- a/lifemonitor/commands/cache.py
+++ b/lifemonitor/commands/cache.py
@@ -29,6 +29,8 @@ logger = logging.getLogger()
 # define the blueprint for DB commands
 blueprint = Blueprint('cache', __name__)
 
+# set help for the CLI command
+blueprint.cli.help = "Manage cache"
 
 @blueprint.cli.command('clear')
 @with_appcontext

--- a/lifemonitor/commands/db.py
+++ b/lifemonitor/commands/db.py
@@ -31,8 +31,8 @@ from lifemonitor.auth.models import User
 # set module level logger
 logger = logging.getLogger()
 
-# define the blueprint for DB commands
-blueprint = Blueprint('init', __name__)
+# update help for the DB command
+cli.db.help = "Manage database"
 
 # set initial revision number
 initial_revision = '8b2e530dc029'

--- a/lifemonitor/commands/db.py
+++ b/lifemonitor/commands/db.py
@@ -102,9 +102,10 @@ def wait_for_db():
 
 
 @cli.db.command()
-@click.option("-f", "--file", default=None, help="Filename (default hhmmss_yyyymmdd.tar")
+@click.option("-f", "--file", default=None, help="Backup filename (default 'hhmmss_yyyymmdd.tar')")
+@click.option("-d", "--directory", default="./", help="Directory path for the backup file (default '.')")
 @with_appcontext
-def backup(file):
+def backup(file, directory):
     """
     Make a backup of the current app database
     """
@@ -112,9 +113,10 @@ def backup(file):
     params = db_connection_params()
     if not file:
         file = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}.tar"
-    cmd = f"PGPASSWORD={params['password']} pg_dump -h {params['host']} -U {params['user']} -F t {params['dbname']} > {file}"
+    target_path = os.path.join(directory, file)
+    cmd = f"PGPASSWORD={params['password']} pg_dump -h {params['host']} -U {params['user']} -F t {params['dbname']} > {target_path}"
     os.system(cmd)
-    msg = f"Created backup of database {params['dbname']} on {file}"
+    msg = f"Created backup of database {params['dbname']} on {target_path}"
     logger.debug(msg)
     print(msg)
 

--- a/lifemonitor/commands/db.py
+++ b/lifemonitor/commands/db.py
@@ -20,16 +20,21 @@
 
 
 import logging
+import os
+import sys
+from datetime import datetime
 
 import click
 from flask import current_app
-from flask.blueprints import Blueprint
 from flask.cli import with_appcontext
-from flask_migrate import current, stamp, upgrade
+from flask_migrate import cli, current, stamp, upgrade
 from lifemonitor.auth.models import User
 
 # set module level logger
 logger = logging.getLogger()
+
+# export from this module
+commands = [cli.db]
 
 # update help for the DB command
 cli.db.help = "Manage database"
@@ -38,12 +43,12 @@ cli.db.help = "Manage database"
 initial_revision = '8b2e530dc029'
 
 
-@blueprint.cli.command('db')
+@cli.db.command()
 @click.option("-r", "--revision", default="head")
 @with_appcontext
-def init_db(revision):
+def init(revision):
     """
-    Initialize LifeMonitor App
+    Initialize app database
     """
     from lifemonitor.db import create_db, db, db_initialized, db_revision
 
@@ -77,11 +82,11 @@ def init_db(revision):
             db.session.commit()
 
 
-@blueprint.cli.command('wait-for-db')
+@cli.db.command()
 @with_appcontext
 def wait_for_db():
     """
-    Wait until that DB is initialized
+    Wait until that DBMS service is up and running
     """
     from lifemonitor.db import db_initialized, db_revision
 

--- a/lifemonitor/commands/oauth.py
+++ b/lifemonitor/commands/oauth.py
@@ -36,6 +36,7 @@ blueprint = Blueprint('oauth', __name__)
 # set CLI help
 blueprint.cli.help = "Manage credentials for OAuth2 clients"
 
+
 def invalidate_token(token):
     invalid_token = token.copy()
     invalid_token["expires_in"] = 10

--- a/lifemonitor/commands/oauth.py
+++ b/lifemonitor/commands/oauth.py
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 # define the blueprint for DB commands
 blueprint = Blueprint('oauth', __name__)
 
+# set CLI help
+blueprint.cli.help = "Manage credentials for OAuth2 clients"
 
 def invalidate_token(token):
     invalid_token = token.copy()

--- a/lifemonitor/commands/registry.py
+++ b/lifemonitor/commands/registry.py
@@ -33,6 +33,9 @@ logger = logging.getLogger(__name__)
 # define the blueprint for DB commands
 blueprint = Blueprint('registry', __name__)
 
+# set CLI help
+blueprint.cli.help = "Manage workflow registries"
+
 # instance of LifeMonitor service
 lm = LifeMonitor.get_instance()
 

--- a/lifemonitor/commands/tasks.py
+++ b/lifemonitor/commands/tasks.py
@@ -29,6 +29,9 @@ logger = logging.getLogger()
 # define the blueprint for DB commands
 blueprint = Blueprint('task-queue', __name__)
 
+# set CLI help
+blueprint.cli.help = "Manage task queue"
+
 
 @blueprint.cli.command('reset')
 @with_appcontext

--- a/lifemonitor/config.py
+++ b/lifemonitor/config.py
@@ -130,6 +130,17 @@ _EXPORT_CONFIGS: List[Type[BaseConfig]] = [
 _config_by_name = {cfg.CONFIG_NAME: cfg for cfg in _EXPORT_CONFIGS}
 
 
+def get_config(settings=None):
+    # set app env
+    app_env = os.environ.get("FLASK_ENV", "production")
+    if app_env != 'production':
+        # Set the DEBUG_METRICS env var to also enable the
+        # prometheus metrics exporter when running in development mode
+        os.environ['DEBUG_METRICS'] = 'true'
+    # load app config
+    return get_config_by_name(app_env, settings=settings)
+
+
 def get_config_by_name(name, settings=None):
     try:
         config = type(f"AppConfigInstance{name}".title(), (_config_by_name[name],), {})

--- a/lifemonitor/db.py
+++ b/lifemonitor/db.py
@@ -154,11 +154,25 @@ def create_db(settings=None, drop=False):
     logger.debug('DB %s created.', new_db_name.string)
 
 
-def drop_db(settings=None):
-    """Clear existing data and create new tables."""
-    actual_db_name = get_db_connection_param("POSTGRESQL_DATABASE", settings)
-    logger.debug("Actual DB name: %r", actual_db_name)
+def rename_db(old_name: str, new_name: str, settings=None):
 
+    db.engine.dispose()
+    con = db_connect(settings=settings, override_db_name='postgres')
+    try:
+        con.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        with con.cursor() as cur:
+            cur.execute(f'ALTER DATABASE {old_name} RENAME TO {new_name}')
+    finally:
+        con.close()
+
+    logger.debug('DB %s renamed to %s.', old_name, new_name)
+
+
+def drop_db(db_name: str=None, settings=None):
+    """Clear existing data and create new tables."""
+    actual_db_name = db_name or get_db_connection_param("POSTGRESQL_DATABASE", settings)
+    logger.debug("Actual DB name: %r", actual_db_name)
+    db.engine.dispose()
     con = db_connect(settings=settings, override_db_name='postgres')
     try:
         con.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)

--- a/lifemonitor/db.py
+++ b/lifemonitor/db.py
@@ -168,7 +168,7 @@ def rename_db(old_name: str, new_name: str, settings=None):
     logger.debug('DB %s renamed to %s.', old_name, new_name)
 
 
-def drop_db(db_name: str=None, settings=None):
+def drop_db(db_name: str = None, settings=None):
     """Clear existing data and create new tables."""
     actual_db_name = db_name or get_db_connection_param("POSTGRESQL_DATABASE", settings)
     logger.debug("Actual DB name: %r", actual_db_name)

--- a/lifemonitor/static/src/package.json
+++ b/lifemonitor/static/src/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lifemonitor",
     "description": "Workflow Testing Service",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "license": "MIT",
     "author": "CRS4",
     "main": "../dist/js/lifemonitor.min.js",

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020-2021 CRS4
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from app import application
+
+
+def main():
+    application.cli.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ VCS = git
 style = pep440
 versionfile_source = lifemonitor/_version.py
 tag_prefix =
+
+[logging]
+filters = connexion,validator

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -3,7 +3,7 @@
 openapi: "3.0.0"
 
 info:
-  version: "0.7.1"
+  version: "0.7.2"
   title: "Life Monitor API"
   description: |
     *Workflow sustainability service*
@@ -18,7 +18,7 @@ info:
 servers:
   - url: /
     description: >
-      Version 0.7.1 of API.
+      Version 0.7.2 of API.
 
 tags:
   - name: Registries


### PR DESCRIPTION
This PR introduces a basic `manage.py` script which acts as entrypoint for the back-end CLI.

The available commands are:

```bash
Usage: manage.py [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  api-key     Manage admin API keys
  cache       Manage cache
  db          Manage database
  oauth       Manage credentials for OAuth2 clients
  registry    Manage workflow registries
  task-queue  Manage task queue
```

The current version of the `db` command includes all the relevant subcommands to: 
* perform the database *initialisation*;
* manage database *migrations*;
* make *backup/restore* of the database

Finally, the k8s chart includes a configurable CronJob to perform automatic backups on a user-defined cluster volume and, optionally, to sync that volume with a remote site via SFTP.