### PR TITLE
Feature/enable Github app notifications

### DIFF
--- a/lifemonitor/auth/models.py
+++ b/lifemonitor/auth/models.py
@@ -337,6 +337,8 @@ class EventType(Enum):
     BUILD_FAILED = 1
     BUILD_RECOVERED = 2
     UNCONFIGURED_EMAIL = 3
+    GITHUB_WORKFLOW_VERSION = 4
+    GITHUB_WORKFLOW_ISSUE = 5
 
     @classmethod
     def all(cls):

--- a/lifemonitor/integrations/github/controllers.py
+++ b/lifemonitor/integrations/github/controllers.py
@@ -37,14 +37,14 @@ from lifemonitor.api.models.repositories.github import GithubWorkflowRepository
 from lifemonitor.api.models.testsuites.testinstance import TestInstance
 from lifemonitor.api.models.wizards import QuestionStep, UpdateStep, Wizard
 from lifemonitor.api.models.workflows import WorkflowVersion
-from lifemonitor.auth.models import EventType, Notification
 from lifemonitor.auth.oauth2.client.models import OAuthIdentity
 from lifemonitor.integrations.github import pull_requests
 from lifemonitor.integrations.github.app import LifeMonitorGithubApp
 from lifemonitor.integrations.github.events import (GithubEvent,
                                                     GithubRepositoryReference)
 from lifemonitor.integrations.github.issues import GithubIssue
-from lifemonitor.integrations.github.notifications import GithubWorkflowVersionNotification
+from lifemonitor.integrations.github.notifications import \
+    GithubWorkflowVersionNotification
 from lifemonitor.integrations.github.settings import GithubUserSettings
 from lifemonitor.integrations.github.utils import delete_branch, match_ref
 from lifemonitor.integrations.github.wizards import GithubWizard

--- a/lifemonitor/integrations/github/notifications.py
+++ b/lifemonitor/integrations/github/notifications.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2020-2021 CRS4
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import logging
+from typing import Dict, List
+
+from flask import render_template
+from flask_mail import Message
+from lifemonitor.auth.models import (EventType, Notification, User,
+                                     UserNotification)
+from lifemonitor.db import db
+from sqlalchemy.exc import InternalError
+
+
+# set logger
+logger = logging.getLogger(__name__)
+
+
+class GithubWorkflowVersionNotification(Notification):
+
+    __mapper_args__ = {
+        'polymorphic_identity': 'github_workflow_version_notification'
+    }
+    
+    @property
+    def get_icon_path(self) -> str:
+        return 'lifemonitor/static/img/logo/providers/github.png'
+
+    def __init__(self, workflow_version: Dict, repository: Dict, action: str, users: List[User], extra_data: Dict = None) -> None:
+        super().__init__(EventType.GITHUB_WORKFLOW_VERSION,
+                         f"workflow {workflow_version['uuid']} version {workflow_version['version']['version']} {action}"
+                         f"(source: {repository['full_name']}, ref: {repository['ref']})",
+                         data={
+                             'action': action,
+                             'repository': repository,
+                             'workflow_version': workflow_version
+                         }, users=users)
+
+    def to_mail_message(self, recipients: List[User]) -> Message:
+        from lifemonitor.mail import mail
+        try:
+            wv = self.data.get('workflow_version', None)
+            repo = self.data.get('repository', None)
+            msg = Message(
+                f'Github workflow version {self.data["action"]}: "{wv["name"]}" (ver. {wv["version"]["version"]})"',
+                bcc=recipients,
+                reply_to=self.reply_to
+            )
+            msg.html = render_template("mail/github_workflow_version_notification.j2",
+                                       webapp_url=mail.webapp_url,
+                                       workflow_version=wv, repository=repo,
+                                       action=self.data["action"],
+                                       json_data=self.data,
+                                       logo=self.base64Logo, icon=self.encodeFile(self.get_icon_path))
+            return msg
+        except InternalError as e:
+            logger.debug(e)
+            db.session.rollback()
+
+    @classmethod
+    def find_by_user(cls, user: User) -> List[Notification]:
+        return cls.query.join(UserNotification, UserNotification.notification_id == cls.id)\
+            .filter(UserNotification.user_id == user.id).all()

--- a/lifemonitor/integrations/github/notifications.py
+++ b/lifemonitor/integrations/github/notifications.py
@@ -38,7 +38,7 @@ class GithubWorkflowVersionNotification(Notification):
     __mapper_args__ = {
         'polymorphic_identity': 'github_workflow_version_notification'
     }
-    
+
     @property
     def get_icon_path(self) -> str:
         return 'lifemonitor/static/img/logo/providers/github.png'

--- a/lifemonitor/integrations/github/services.py
+++ b/lifemonitor/integrations/github/services.py
@@ -90,7 +90,18 @@ def __get_registries_map__(w: Workflow, registries: List[str]):
     return registries_map
 
 
-def register_repository_workflow(repository_reference: GithubRepositoryReference, registries: List[str] = None):
+def find_workflow_version(repository_reference: GithubRepositoryReference) -> Tuple[Workflow, WorkflowVersion]:
+    # found the existing workflow associated with repo
+    github_registry: GithubWorkflowRegistry = repository_reference.event.installation.github_registry
+    workflow_version = None
+    workflow = github_registry.find_workflow(repository_reference.repository.full_name)
+    if workflow:
+        workflow_version = workflow.versions.get(repository_reference.branch or repository_reference.tag, None)
+        logger.debug("Found workflow version: %r", workflow_version)
+    return workflow, workflow_version
+
+
+def register_repository_workflow(repository_reference: GithubRepositoryReference, registries: List[str] = None) -> WorkflowVersion:
     logger.debug("Repository ref: %r", repository_reference)
     # set a reference to LifeMonitorService
     lm = LifeMonitor.get_instance()

--- a/lifemonitor/integrations/github/services.py
+++ b/lifemonitor/integrations/github/services.py
@@ -21,8 +21,9 @@
 from __future__ import annotations
 
 import logging
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
+from lifemonitor.api import serializers
 from lifemonitor.api.models.registries.registry import WorkflowRegistry
 from lifemonitor.api.models.repositories.base import IssueCheckResult
 from lifemonitor.api.models.repositories.github import GithubWorkflowRepository

--- a/lifemonitor/mail.py
+++ b/lifemonitor/mail.py
@@ -86,7 +86,7 @@ def send_notification(n: Notification, recipients: List[str] = None) -> Optional
                         conn.send(msg)
                         return datetime.utcnow()
                     else:
-                        logger.warning("Notification %r cannot be sent by email", n)                    
+                        logger.warning("Notification %r cannot be sent by email", n)
                 except Exception as e:
                     logger.error(str(e))
                     if logger.isEnabledFor(logging.DEBUG):

--- a/lifemonitor/mail.py
+++ b/lifemonitor/mail.py
@@ -81,8 +81,14 @@ def send_notification(n: Notification, recipients: List[str] = None) -> Optional
                 ]
             if len(recipients) > 0:
                 try:
-                    conn.send(n.to_mail_message(recipients))
-                    return datetime.utcnow()
+                    msg = n.to_mail_message(recipients)
+                    if msg:
+                        conn.send(msg)
+                        return datetime.utcnow()
+                    else:
+                        logger.warning("Notification %r cannot be sent by email", n)                    
                 except Exception as e:
-                    logger.debug(e)
+                    logger.error(str(e))
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.exception(e)
     return None

--- a/lifemonitor/templates/mail/github_workflow_version_notification.j2
+++ b/lifemonitor/templates/mail/github_workflow_version_notification.j2
@@ -1,0 +1,98 @@
+<html>
+<head>
+  <!-- include font -->
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;600&amp;family=Roboto+Mono&amp;display=swap"
+    rel="stylesheet">
+  <style>
+    body {
+      font-family: "Open Sans";
+      font-size: 16px;
+      font-weight: 200;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4 {
+      font-weight: 150;
+      color: hsl(180, 63%, 33%);
+    }
+
+    a:link,
+    a:visited {
+      color: hsl(180, 63%, 33%);
+      text-decoration: none;
+    }
+
+    a:hover,
+    a:active {
+      color: #003333;
+      text-decoration: none;
+    }
+
+    a.button:link,
+    a.button:visited {
+      background-color: hsl(180, 63%, 33%);
+      color: white;
+      padding: 14px 25px;
+      text-align: center;
+      text-decoration: none;
+      display: inline-block;
+    }
+
+    a.button:hover,
+    a.button:active {
+      background-color: #003333;
+    }
+
+    div.details-box {
+      width: 400px;
+      margin: 25px auto;
+      padding: 10px;
+      background: whitesmoke;
+      border-radius: 10px;
+    }
+
+  </style>
+</head>
+<body>
+  <div style="text-align: center;">
+    <img alt="My Image" src="data:image/png;base64,{{logo}}" height="80px" />
+
+    <h1>
+      <b>{{workflow_version['name']}}</b> <br>
+      <span style="font-size: 12pt">(version {{workflow_version['version']['version']}})</span>
+    </h1>
+
+    <h2 style="color: gray">
+      {{ action }} through
+    </h2>
+
+    <div style="padding: 25px;">
+      <img src="data:image/png;base64,{{icon}}" alt="triangle with all three sides equal" height="100px">
+    </div>
+
+    <a href="{{repository['html_url']}}/tree/{{repository['ref']}}" title="Github repo: {{repository['full_name']}}" style="color: black" target="_blank">
+      <h2 style="color: black" >
+        <b>repository:</b>          
+          {{repository['full_name']}}        
+      </h2> 
+    </a>
+    <div class="details-box">
+      <div>
+        <b>reference:</b> {{repository['ref']}}
+      </div>
+    </div>
+
+    <div style="padding: 25px;">
+      {% if action == 'deleted' %}
+      <a class="button" target="_blank" href="{{webapp_url}}/workflow;uuid={{workflow_version['uuid']}}">
+      {% else %}
+      <a class="button" target="_blank" href="{{webapp_url}}/workflow;uuid={{workflow_version['uuid']}};version={{workflow_version['version']['version']}}">
+      {% endif %}
+        View on LifeMonitor
+      </a>
+    </div>
+    <div>
+</body>
+</html>

--- a/lifemonitor/templates/repositories/base/lifemonitor.yaml.j2
+++ b/lifemonitor/templates/repositories/base/lifemonitor.yaml.j2
@@ -26,8 +26,10 @@ push:
     #                                   # (e.g., https://api.lifemontor.eu/registries)
     - name: "{{main_branch}}"
       update_registries: []
+      enable_notifications: true
     # - name: "develop"
     #   update_registries: []
+    #   enable_notifications: true
 
   tags:
     # Define the list of tags to watch
@@ -37,5 +39,7 @@ push:
     #                                   # (e.g., https://api.lifemontor.eu/registries)
     - name: "v*.*.*"
       update_registries: [{{registries|join(', ', attribute="name")}}]
+      enable_notifications: true
     - name: "*.*.*"
       update_registries: [{{registries|join(', ', attribute="name")}}]
+      enable_notifications: true


### PR DESCRIPTION
Allow Github app to notify users when a workflow version has been created/updated/deleted.

* Notifications are enabled by default, but they can be turned off per branch/tag through the `lifemonitor.yaml` configuration file:

```yaml
...

# Github Integration Settings
push:
    branches:
        - name: "main"
          update_registries: []
          enable_notifications: false
        - name: "develop"
          update_registries: []

    tags:
        - name: "*.*.*"
          update_registries: [wfhubdev]
          enable_notifications: true
```

* Notifications are sent via email if email notifications are enabled:
![Screenshot 2022-05-26 at 16 25 03](https://user-images.githubusercontent.com/1832243/170525336-c8aabfe4-1d4f-4c77-8e8c-8b9fa4920cad.png)


