### PR TITLE
Feature/GitHub app with multiple LM instances

### DIFF
--- a/k8s/templates/secret.yaml
+++ b/k8s/templates/secret.yaml
@@ -129,10 +129,17 @@ stringData:
     {{- end }}
     {{- end }}
 
-    # Set configuration of the remote storage
     {{- if .Values.remoteStorage.enabled -}}
+    # Set configuration of the remote storage
     S3_ENDPOINT_URL={{ .Values.remoteStorage.endpoint_url }}
     S3_ACCESS_KEY={{ .Values.remoteStorage.s3_access_key }}
     S3_SECRET_KEY={{ .Values.remoteStorage.s3_secret_key }}
     S3_BUCKET={{ .Values.remoteStorage.bucket_name }}
+    {{- end }}
+
+    {{- if .Values.proxy.instances -}}
+    # Set proxy entries
+    {{- range $k, $v := .Values.proxy.instances }}
+    PROXY_{{ $v.name | upper }}_URL={{ $v.url }}
+    {{- end }}
     {{- end }}

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -91,6 +91,13 @@ cache:
     workflow: 1800
     build: 84600
 
+proxy:
+  instances: []
+  # - name: production
+  #   url: https://api.lifemonitor.eu
+  # - name: development
+  #   url: https://api.dev.lifemonitor.eu
+
 # Email settings
 mail:
   server: ""

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -18,7 +18,7 @@ storageClass: &storageClass "-"
 
 remoteStorage:
   enabled: false
-  s3_endpoint_url: 'https://your-s3-storage-url'
+  s3_endpoint_url: "https://your-s3-storage-url"
   s3_access_key: <YOUR_ACCESS_KEY>
   s3_secret_key: <YOUR_SECRET_KEY>
 

--- a/lifemonitor/api/models/repositories/config.py
+++ b/lifemonitor/api/models/repositories/config.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import lifemonitor.api.models as models
 import yaml
@@ -96,6 +96,16 @@ class WorkflowRepositoryConfig(RepositoryFile):
         if on_push and refs:
             return [_ for ref in refs.split(",") for _ in on_push.get(ref, [])]
         return []
+
+    def _get_ref_settings(self, ref: str, ref_type: str) -> Optional[Dict]:
+        ref_pattern = match_ref(ref, self.branches if ref_type == 'branch' else self.tags)
+        if not ref_pattern:
+            return None
+        logger.debug(f"ref {ref} matched with pattern {ref_pattern}")
+        return next((r for r in self._raw_data['push']['branches' if ref_type == 'branch' else 'tags'] if r["name"] == ref_pattern[1]), None)
+
+    def get_ref_settings(self, ref: str) -> Optional[Dict]:
+        return self._get_ref_settings(ref, 'branch') or self._get_ref_settings(ref, 'tag') or None
 
     @property
     def registries(self) -> List[models.WorkflowRegistry]:

--- a/lifemonitor/api/models/repositories/config.py
+++ b/lifemonitor/api/models/repositories/config.py
@@ -26,6 +26,7 @@ from typing import Dict, List
 
 import lifemonitor.api.models as models
 import yaml
+from lifemonitor.utils import match_ref
 
 from .files import RepositoryFile, TemplateRepositoryFile
 

--- a/lifemonitor/app.py
+++ b/lifemonitor/app.py
@@ -75,6 +75,8 @@ def create_app(env=None, settings=None, init_app=True, worker=False, load_jobs=T
         app.config.from_envvar("FLASK_APP_CONFIG_FILE")
     # set worker flag
     app.config['WORKER'] = worker
+    # append proxy settings
+    app.config['PROXY_ENTRIES'] = config.load_proxy_entries(app.config)
 
     # initialize the application
     if init_app:

--- a/lifemonitor/config.py
+++ b/lifemonitor/config.py
@@ -28,8 +28,6 @@ from typing import List, Type
 import dotenv
 from flask import current_app
 
-from lifemonitor.utils import get_external_server_url
-
 from .db import db_uri
 
 basedir = os.path.abspath(os.path.dirname(__file__))
@@ -63,6 +61,7 @@ def load_proxy_entries(config=None):
     pattern = re.compile(r'PROXY_(.+)_URL')
     result = {}
     try:
+        from .utils import get_external_server_url
         result['default'] = {'name': 'default', 'url': get_external_server_url()}
     except KeyError:
         pass

--- a/lifemonitor/config.py
+++ b/lifemonitor/config.py
@@ -28,6 +28,8 @@ from typing import List, Type
 import dotenv
 from flask import current_app
 
+from lifemonitor.utils import get_external_server_url
+
 from .db import db_uri
 
 basedir = os.path.abspath(os.path.dirname(__file__))
@@ -61,7 +63,7 @@ def load_proxy_entries(config=None):
     pattern = re.compile(r'PROXY_(.+)_URL')
     result = {}
     try:
-        result['default'] = {'name': 'default', 'url': f"https://{config['SERVER_NAME']}"}
+        result['default'] = {'name': 'default', 'url': get_external_server_url()}
     except KeyError:
         pass
     for k in config:

--- a/lifemonitor/integrations/github/controllers.py
+++ b/lifemonitor/integrations/github/controllers.py
@@ -310,6 +310,10 @@ def __forward_event__(event: GithubEvent) -> Optional[Dict]:
     logger.debug("Repository: %r", repo)
 
     config: WorkflowRepositoryConfig = repo.config
+    if not config:
+        logger.debug("No config file found")
+        return None
+
     logger.error("Workflow repository config: %r", config._raw_data)
 
     ref = repo_info.branch or repo_info.tag

--- a/lifemonitor/integrations/github/controllers.py
+++ b/lifemonitor/integrations/github/controllers.py
@@ -42,10 +42,11 @@ from lifemonitor.integrations.github.issues import GithubIssue
 from lifemonitor.integrations.github.notifications import \
     GithubWorkflowVersionNotification
 from lifemonitor.integrations.github.settings import GithubUserSettings
-from lifemonitor.integrations.github.utils import delete_branch, match_ref
+from lifemonitor.integrations.github.utils import delete_branch
 from lifemonitor.integrations.github.wizards import GithubWizard
 from lifemonitor.tasks import Scheduler
-from lifemonitor.utils import bool_from_string, get_git_repo_revision
+from lifemonitor.utils import (bool_from_string, get_git_repo_revision,
+                               match_ref)
 
 from github.PullRequest import PullRequest
 

--- a/lifemonitor/integrations/github/controllers.py
+++ b/lifemonitor/integrations/github/controllers.py
@@ -21,14 +21,17 @@
 from __future__ import annotations
 
 import logging
+import os
 from tempfile import TemporaryDirectory
-from typing import Callable, Dict, List, Union
+from typing import Callable, Dict, List, Optional, Union
 
+import requests
 from flask import Blueprint, Flask, current_app, request
 from lifemonitor import cache
 from lifemonitor.api import serializers
 from lifemonitor.api.models import WorkflowRegistry
 from lifemonitor.api.models.registries.settings import RegistrySettings
+from lifemonitor.api.models.repositories.config import WorkflowRepositoryConfig
 from lifemonitor.api.models.repositories.github import GithubWorkflowRepository
 from lifemonitor.api.models.testsuites.testinstance import TestInstance
 from lifemonitor.api.models.wizards import QuestionStep, UpdateStep
@@ -297,6 +300,52 @@ def __skip_branch_or_tag__(repo_info: GithubRepositoryReference,
         if user_settings.all_branches or user_settings.is_valid_branch(repo_info.branch):
             return False
     return True
+
+
+def __forward_event__(event: GithubEvent) -> Optional[Dict]:
+    repo_info = event.repository_reference
+    logger.debug("Repo reference: %r", repo_info)
+
+    repo: GithubWorkflowRepository = repo_info.repository
+    logger.debug("Repository: %r", repo)
+
+    config: WorkflowRepositoryConfig = repo.config
+    logger.error("Workflow repository config: %r", config._raw_data)
+
+    ref = repo_info.branch or repo_info.tag
+    logger.error("Ref: %s", ref)
+
+    ref_settings = repo.config.get_ref_settings(ref)
+    logger.warning("Repo ref settings: %r", ref_settings)
+
+    default_instance_info = current_app.config['PROXY_ENTRIES']['default']
+    logger.debug("Default LM instance: %r", default_instance_info)
+
+    if ref_settings:
+        lm_instance_name = ref_settings.get('lifemonitor_instance', None)
+        if lm_instance_name:
+            lm_instance_info = current_app.config['PROXY_ENTRIES'][lm_instance_name]
+            assert lm_instance_info, "Undefined instance info"
+            if lm_instance_info['url'] != default_instance_info['url']:
+                logger.warning("Using LM instance: %r", lm_instance_info)
+                redirect_url = os.path.join(lm_instance_info['url'], 'integrations/github')
+                logger.debug("Redirecting to: %r", redirect_url)
+                response = requests.request(
+                    method=request.method,
+                    url=redirect_url,
+                    headers={key: value for (key, value) in request.headers if key != 'Host'},
+                    data=request.get_data(),
+                    cookies=request.cookies,
+                    allow_redirects=False,
+                    stream=True)
+                logger.debug("Respose: %r", response.content)
+                return lm_instance_info
+        else:
+            logger.debug("No settings found for ref: %s", ref)
+
+    # Fallback to the default/current LifeMonitor instance
+    logger.warning("Using default lifemonitor: %s", default_instance_info)
+    return None
 
 
 def __check_for_issues_and_register__(repo_info: GithubRepositoryReference,
@@ -700,6 +749,11 @@ def handle_event():
     logger.debug("Signature valid?: %r", valid)
     if not valid:
         return "Signature Invalid", 401
+
+    # Forward request to another LifeMonitor instance if required
+    forwarded_to = __forward_event__(event)
+    if forwarded_to:
+        return f"Event forwarded to LifeMonitor instance '{forwarded_to['name']}' (url: {forwarded_to['url']})"
 
     # Submit event to an async handler
     event_handler = __event_handlers__.get(event.type, None)

--- a/lifemonitor/integrations/github/controllers.py
+++ b/lifemonitor/integrations/github/controllers.py
@@ -347,7 +347,7 @@ def __forward_event__(event: GithubEvent) -> Optional[Dict]:
         else:
             logger.debug("No settings found for ref: %s", ref)
 
-    # Fallback to the default/current LifeMonitor instance
+    # Fall back to the default/current LifeMonitor instance
     logger.warning("Using default lifemonitor: %s", default_instance_info)
     return None
 

--- a/lifemonitor/integrations/github/settings.py
+++ b/lifemonitor/integrations/github/settings.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from typing import List
 
 from lifemonitor.auth.models import User
-from lifemonitor.integrations.github.utils import match_ref
+from lifemonitor.utils import match_ref
 from sqlalchemy.orm.attributes import flag_modified
 
 

--- a/lifemonitor/integrations/github/utils.py
+++ b/lifemonitor/integrations/github/utils.py
@@ -46,22 +46,6 @@ from ...api.models.wizards import (IOHandler, QuestionStep, Step, UpdateStep,
 logger = logging.getLogger(__name__)
 
 
-def match_ref(ref: str, refs: List[str]) -> str:
-    if not ref:
-        return None
-    for v in refs:
-        pattern = rf"^({v})$".replace('*', "[a-zA-Z0-9-_/]+")
-        try:
-            logger.debug("Searching match for %s (pattern: %s)", ref, pattern)
-            match = re.match(pattern, ref)
-            if match:
-                logger.debug("Match found: %r", match)
-                return (match.group(0), pattern.replace("[a-zA-Z0-9-_/]+", '*').strip('^()$'))
-        except Exception:
-            logger.debug("Unable to find a match for %s (pattern: %s)", ref, pattern)
-    return None
-
-
 def crate_branch(repo: Repository, branch_name: str, rev: str = None) -> GitRef:
     head = repo.get_commit(rev or repo.rev or 'HEAD')
     logger.debug("HEAD commit: %r", head.sha)

--- a/lifemonitor/templates/repositories/base/lifemonitor.yaml.j2
+++ b/lifemonitor/templates/repositories/base/lifemonitor.yaml.j2
@@ -20,16 +20,20 @@ issues:
 push:
   branches:
     # Define the list of branches to watch
-    # - name: feature/XXX               # wildcards can be used to specify branches (e.g., feature/*)
-    #   update_registries: ["wfhubdev"] # available registries are listed
-    #                                   # by the endpoint `<lifemonitor_url>/registries`
-    #                                   # (e.g., https://api.lifemontor.eu/registries)
+    # - name: feature/XXX                   # wildcards can be used to specify branches (e.g., feature/*)
+    #   update_registries: ["wfhubdev"]     # available registries are listed
+    #                                       # by the endpoint `<lifemonitor_url>/registries`
+    #                                       # (e.g., https://api.lifemontor.eu/registries)
+    #   lifemonitor_instance: development   # uncomment to use the 'development' instance of LifeMonitor
+    #                                       # (the 'production' instance is used by default)
     - name: "{{main_branch}}"
       update_registries: []
       enable_notifications: true
+      # lifemonitor_instance: development
     # - name: "develop"
     #   update_registries: []
     #   enable_notifications: true
+    #   lifemonitor_instance: development
 
   tags:
     # Define the list of tags to watch
@@ -37,9 +41,13 @@ push:
     #   update_registries: ["wfhub"]    # available registries are listed
     #                                   # by the endpoint `<lifemonitor_url>/registries`
     #                                   # (e.g., https://api.lifemontor.eu/registries)
+    #   lifemonitor_instance: development   # uncomment to use the 'development' instance of LifeMonitor
+    #                                       # (the 'production' instance is used by default)
     - name: "v*.*.*"
       update_registries: [{{registries|join(', ', attribute="client_name")}}]
       enable_notifications: true
+      # lifemonitor_instance: development
     - name: "*.*.*"
       update_registries: [{{registries|join(', ', attribute="client_name")}}]
       enable_notifications: true
+      # lifemonitor_instance: development

--- a/lifemonitor/utils.py
+++ b/lifemonitor/utils.py
@@ -40,7 +40,7 @@ import zipfile
 from datetime import datetime
 from importlib import import_module
 from os.path import basename, dirname, isfile, join
-from typing import Dict, List, Type
+from typing import Dict, List, Optional, Tuple, Type
 
 import flask
 import networkx as nx
@@ -215,6 +215,22 @@ def validate_url(url: str) -> bool:
 
 def get_last_update(path: str):
     return time.ctime(max(os.stat(root).st_mtime for root, _, _ in os.walk(path)))
+
+
+def match_ref(ref: str, refs: List[str]) -> Optional[Tuple[str, str]]:
+    if not ref:
+        return None
+    for v in refs:
+        pattern = rf"^({v})$".replace('*', "[a-zA-Z0-9-_/]+")
+        try:
+            logger.debug("Searching match for %s (pattern: %s)", ref, pattern)
+            match = re.match(pattern, ref)
+            if match:
+                logger.debug("Match found: %r", match)
+                return (match.group(0), pattern.replace("[a-zA-Z0-9-_/]+", '*').strip('^()$'))
+        except Exception:
+            logger.debug("Unable to find a match for %s (pattern: %s)", ref, pattern)
+    return None
 
 
 def load_modules(path: str = None, include: List[str] = None, exclude: List[str] = None) -> Dict[str, Type]:

--- a/settings.conf
+++ b/settings.conf
@@ -103,7 +103,7 @@ BACKUP_RETAIN_DAYS=30
 
 # Set access tokens for testing services.
 # Associate the access token <SERVICE_ACCESS_TOKEN> to the testing service
-# available at <SERVICE_URL> by setting a pair of config variables like:
+# available at <SERVICE_URL> by setting the following config variables:
 #     <SERVICE_LABEL>_TESTING_SERVICE_URL=<SERVICE_URL>
 #     <SERVICE_LABEL>_TESTING_SERVICE_TOKEN=<SERVICE_ACCESS_TOKEN>
 #     <SERVICE_LABEL>_TESTING_SERVICE_TYPE=[github,jenkins,travis]

--- a/settings.conf
+++ b/settings.conf
@@ -137,3 +137,10 @@ BACKUP_RETAIN_DAYS=30
 #
 # GITHUB_INTEGRATION_EVENTS_CHANNEL=<YOUR_SMEE.IO_CHANNEL>
 
+# Configure entries to enable forwarding of GitHub push notifications
+# to other LifeMonitor instances. LifeMonitor instances can specified by setting 
+# a variable like: PROXY_<INSTANCE_NAME>_URL = <API_INSTANCE_URL>
+# e.g., PROXY_PRODUCTION_URL = https://api.lifemonitor.eu
+#
+# PROXY_PRODUCTION_URL = https://api.lifemonitor.eu
+# PROXY_DEVELOPMENT_URL = https://api.dev.lifemonitor.eu


### PR DESCRIPTION
This PR allows to use the same GitHub app setup with multiple LifeMonitor instances.
Every LifeMonitor instance acts as a proxy for the other instances connected to the same GitHub app configuration.
The `lifemonitor.yaml` configuration file allows users to choose which LifeMonitor instance should handle which branch or tag.