### PR TITLE
feature/improve GitHub App installation

### DIFF
--- a/lifemonitor/cache.py
+++ b/lifemonitor/cache.py
@@ -406,6 +406,13 @@ class Cache(object):
         logger.debug("Current cache data: %r", data is not None)
         return pickle.loads(data) if data is not None else data
 
+    def delete(self, key: str, prefix: str = CACHE_PREFIX):
+        logger.debug(f"Deleting key: {key}")
+        if self.cache_enabled:
+            logger.debug("Redis backend detected!")
+            logger.debug(f"Pattern: {prefix}{key}")
+            self.backend.delete(self._make_key(key, prefix=prefix))
+
     def delete_keys(self, pattern: str, prefix: str = CACHE_PREFIX):
         logger.debug(f"Deleting keys by pattern: {pattern}")
         if self.cache_enabled:

--- a/lifemonitor/integrations/github/controllers.py
+++ b/lifemonitor/integrations/github/controllers.py
@@ -30,6 +30,8 @@ import requests
 from flask import (Blueprint, Flask, current_app, redirect, render_template,
                    request)
 from flask_login import login_required
+from github.PullRequest import PullRequest
+
 from lifemonitor import cache
 from lifemonitor.api import serializers
 from lifemonitor.api.models import WorkflowRegistry
@@ -39,7 +41,9 @@ from lifemonitor.api.models.repositories.github import GithubWorkflowRepository
 from lifemonitor.api.models.testsuites.testinstance import TestInstance
 from lifemonitor.api.models.wizards import QuestionStep, UpdateStep
 from lifemonitor.api.models.workflows import WorkflowVersion
+from lifemonitor.auth.models import User
 from lifemonitor.auth.oauth2.client.models import OAuthIdentity
+from lifemonitor.auth.services import authorized, current_user
 from lifemonitor.integrations.github import pull_requests
 from lifemonitor.integrations.github.app import LifeMonitorGithubApp
 from lifemonitor.integrations.github.events import (GithubEvent,
@@ -53,8 +57,6 @@ from lifemonitor.integrations.github.wizards import GithubWizard
 from lifemonitor.tasks import Scheduler
 from lifemonitor.utils import (bool_from_string, get_git_repo_revision,
                                match_ref)
-
-from github.PullRequest import PullRequest
 
 from . import services
 

--- a/lifemonitor/integrations/github/controllers.py
+++ b/lifemonitor/integrations/github/controllers.py
@@ -22,11 +22,14 @@ from __future__ import annotations
 
 import logging
 import os
+import uuid
 from tempfile import TemporaryDirectory
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import requests
-from flask import Blueprint, Flask, current_app, request
+from flask import (Blueprint, Flask, current_app, redirect, render_template,
+                   request)
+from flask_login import login_required
 from lifemonitor import cache
 from lifemonitor.api import serializers
 from lifemonitor.api.models import WorkflowRegistry
@@ -722,6 +725,19 @@ blueprint = Blueprint("github_integration", __name__,
                       template_folder='templates',
                       static_folder="static", static_url_path='/static')
 
+
+@authorized
+@blueprint.route("/integrations/github/installation/new", methods=("GET",))
+def handle_registration_new():
+    # get a reference to the LifeMonitor Github App
+    gh_app = LifeMonitorGithubApp.get_instance()
+    # build the current state
+    state_id = uuid.uuid4()
+    # state: Dict[str, Any] = _get_state()
+    # save the created state on cache
+    # cache.cache.set(f"{state_id}", state)
+    # redirect to Github App registration endpoint
+    return redirect(f'https://github.com/apps/{gh_app.name}/installations/new?state={state_id}')
 
 @blueprint.route("/integrations/github", methods=("POST",))
 def handle_event():

--- a/lifemonitor/integrations/github/controllers.py
+++ b/lifemonitor/integrations/github/controllers.py
@@ -729,7 +729,7 @@ blueprint = Blueprint("github_integration", __name__,
 
 
 @authorized
-@blueprint.route("/integrations/github/installation/new", methods=("GET",))
+@blueprint.route("/integrations/github/installations/new", methods=("GET",))
 def handle_registration_new():
     # get a reference to the LifeMonitor Github App
     gh_app = LifeMonitorGithubApp.get_instance()
@@ -742,7 +742,7 @@ def handle_registration_new():
     return redirect(f'https://github.com/apps/{gh_app.name}/installations/new?state={state_id}')
 
 
-@blueprint.route("/integrations/github/installation/callback", methods=("GET",))
+@blueprint.route("/integrations/github/installations/callback", methods=("GET",))
 @login_required
 def handle_registration_callback():
     logger.debug(request.args)

--- a/lifemonitor/integrations/github/settings.py
+++ b/lifemonitor/integrations/github/settings.py
@@ -145,11 +145,12 @@ class GithubUserSettings():
         return data
 
     def remove_installation(self, installation_id: str):
-        del self._raw_settings['installations'][str(installation_id)]
-        flag_modified(self.user, 'settings')
+        if "installations" in self._raw_settings:
+            del self._raw_settings['installations'][str(installation_id)]
+            flag_modified(self.user, 'settings')
 
     def get_installation(self, installation_id: str) -> Dict[str, Any]:
-        return self._raw_settings['installations'].get(str(installation_id), None)
+        return self._installations.get(str(installation_id), None)
 
     def add_installation_repository(self, installation_id: str, repo_fullname: str, repository_info: Dict[str, Any]):
         inst = self.get_installation(str(installation_id))

--- a/lifemonitor/integrations/github/settings.py
+++ b/lifemonitor/integrations/github/settings.py
@@ -20,11 +20,16 @@
 
 from __future__ import annotations
 
-from typing import List
+import logging
+from typing import Any, Dict, List
+
+from sqlalchemy.orm.attributes import flag_modified
 
 from lifemonitor.auth.models import User
 from lifemonitor.utils import match_ref
-from sqlalchemy.orm.attributes import flag_modified
+
+# Config a module level logger
+logger = logging.getLogger(__name__)
 
 
 class GithubUserSettings():
@@ -36,12 +41,13 @@ class GithubUserSettings():
         "all_tags": True,
         "branches": ["main"],
         "tags": ["v*.*.*"],
-        "registries": []
+        "registries": [],
+        "installations": {}
     }
 
     def __init__(self, user: User) -> None:
         self.user = user
-        self._raw_settings = self.user.settings.get('github_settings', None)
+        self._raw_settings: Dict[str, Any] = self.user.settings.get('github_settings', None)  # type: ignore
         if not self._raw_settings:
             self._raw_settings = self.DEFAULTS.copy()
             self.user.settings['github_settings'] = self._raw_settings
@@ -116,6 +122,51 @@ class GithubUserSettings():
 
     def is_valid_tag(self, tag: str) -> bool:
         return match_ref(tag, self.tags)
+
+    @property
+    def installations(self) -> List[Dict[str, Any]]:
+        result = self._raw_settings.get('installations', None)
+        return list(result.values()) if result else []
+
+    @property
+    def _installations(self) -> Dict[str, Any]:
+        if "installations" not in self._raw_settings:
+            self._raw_settings["installations"] = {}
+        return self._raw_settings["installations"]
+
+    def add_installation(self, installation_id: str, info: Dict[str, Any]) -> Dict[str, Any]:
+        data = {
+            "id": installation_id,
+            "info": info,
+            "repositories": {}
+        }
+        self._installations[str(installation_id)] = data
+        flag_modified(self.user, 'settings')
+        return data
+
+    def remove_installation(self, installation_id: str):
+        del self._raw_settings['installations'][str(installation_id)]
+        flag_modified(self.user, 'settings')
+
+    def get_installation(self, installation_id: str) -> Dict[str, Any]:
+        return self._raw_settings['installations'].get(str(installation_id), None)
+
+    def add_installation_repository(self, installation_id: str, repo_fullname: str, repository_info: Dict[str, Any]):
+        inst = self.get_installation(str(installation_id))
+        assert inst, f"Unable to find installation '{installation_id}'"
+        inst['repositories'][repo_fullname] = repository_info
+        flag_modified(self.user, 'settings')
+
+    def remove_installation_repository(self, installation_id: str, repo_fullname: str):
+        inst = self.get_installation(installation_id)
+        assert inst, f"Unable to find installation '{installation_id}'"
+        del inst['repositories'][repo_fullname]
+        flag_modified(self.user, 'settings')
+
+    def get_installation_repositories(self, installation_id: str) -> Dict[str, Any]:
+        inst = self.get_installation(installation_id)
+        logger.debug("Installation: %r", inst)
+        return {k: v for k, v in inst['repositories'].items()} if inst else {}
 
     @property
     def registries(self) -> List[str]:

--- a/lifemonitor/integrations/github/templates/github_integration/registration.j2
+++ b/lifemonitor/integrations/github/templates/github_integration/registration.j2
@@ -24,7 +24,7 @@
 
           <div style="font-size: 0.6em; margin-bottom: -5px;">GitHub Account</div>
           <div>
-            <a class="mt-1 p-0" style="font-weight: bold;" href="{{ installation.account.html_url }}">
+            <a class="mt-1 p-0" style="font-weight: bold;" href="{{ installation.account.html_url }}" target="_blank">
               {{ installation.account.login }}
             </a>
           </div>
@@ -80,7 +80,7 @@
           </td>
           <td></td>
           <td>
-            <a href="{{r.html_url}}">
+            <a href="{{r.html_url}}" target="_blank">
               <i class="far fa-folder-open mx-2"></i>              
             </a>
         </tr>
@@ -110,7 +110,7 @@
           <td>{{r.full_name}}</td>
           <td></td>
           <td>
-            <a href="{{r.html_url}}">
+            <a href="{{r.html_url}}" target="_blank">
               <i class="far fa-folder-open mx-2"></i>              
             </a>
         </tr>
@@ -121,7 +121,7 @@
 
     <div class="container-sm text-center p-4 mt-5">
       <div class="form-group pt-5 text-center d-inline">
-        <a type="button" href="{{webapp_url}}"
+        <a type="button" href="{{webapp_url}}" target="_blank"
           class="btn btn-primary text-bold" style="width: 175px">
           Dashboard
         </a>
@@ -129,12 +129,12 @@
 
       <div class="form-group pt-5 text-center d-inline">
         <a type="button" class="btn btn-primary text-bold" style="width: 175px"
-          href="/profile?currentView=githubSettingsTab">Settings</a>
+          href="/profile?currentView=githubSettingsTab" target="_blank">Settings</a>
       </div>
 
       <div class="form-group pt-5 text-center d-inline">
         <a type="button" href="https://github.com/settings/installations/{{installation.id}}"
-          class="btn btn-primary text-bold" style="width: 175px">Manage</a>
+          class="btn btn-primary text-bold" style="width: 175px" target="_blank">Manage</a>
       </div>
     </div>
   </div>

--- a/lifemonitor/integrations/github/templates/github_integration/registration.j2
+++ b/lifemonitor/integrations/github/templates/github_integration/registration.j2
@@ -1,0 +1,145 @@
+{% extends 'auth/base.j2' %}
+{% import 'auth/macros.j2' as macros %}
+
+{% block body_class %} login-page {% endblock %}
+{% block body_style %} height: auto; {% endblock %}
+
+{% block body %}
+
+<div class="mx-5" style="margin-top: 10%;">
+  <div class="text-center align-middle h-100 my-auto">
+    <div class="row h-100 my-auto align-items-center">
+      <div class="col-3">
+        <img style="width: 8em;" {% if config.get('ENV')=='production' %}
+          src="{{ url_for('auth.static', filename='img/logo/lm/LifeMonitorLogo.png') }}" {% else %}
+          src="{{ url_for('auth.static', filename='img/logo/lm/LifeMonitorLogo-dev.png') }}" {% endif %}
+          alt="LifeMonitor Logo" class="" />
+      </div>
+      <div class="col-2">
+        ---------
+      </div>
+      <div class="col-2 text-center" style="width: 100%;">
+        <img src="{{ installation.account.avatar_url }}" style="width: 60px;">
+        <div class="text-center" style="text-align: center;">
+
+          <div style="font-size: 0.6em; margin-bottom: -5px;">GitHub Account</div>
+          <div>
+            <a class="mt-1 p-0" style="font-weight: bold;" href="{{ installation.account.html_url }}">
+              {{ installation.account.login }}
+            </a>
+          </div>
+        </div>
+      </div>
+      <div class="col-2">
+        -----------
+      </div>
+      <div class="col-3">
+        <img style="width: 9em;" src="{{ url_for('auth.static', filename='img/logo/providers/github.png') }}" />
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Main content -->
+<div class="container-sm">
+  <div class="card card-primary card-outline mx-5 my-4 p-5">
+    <h3 class="text-center p-0 m-0" style="color: #133233">
+      <span
+        style="font-style: italic; font-family: Baskerville,Baskerville Old Face,Hoefler Text,Garamond,Times New Roman,serif;">Life</span>
+      <span class="small" style="font-size: 75%; margin: 0 -5px 0 -5px;">-</span>
+      <span style="font-weight: bold; font-family: Gill Sans,Gill Sans MT,Calibri,sans-serif;">Monitor</span>
+      GitHub App installed!<br />
+    </h3>
+
+    <!-- added repositories -->
+    {% if installation_repositories %}
+    <h5 class="mt-5 text-bold">Grant access to:</h5>
+
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th style="width: 5px"></th>
+          <th>Repository</th>
+          <th style="width: 100px"></th>
+          <th style="width: 120px"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in installation_repositories %}
+        <tr>
+          <td><i class="fab fa-github mr-1"></i></td>
+          <td>
+            {% if r.full_name in added_repos %}
+            <span class="font-italic text-bold">{{r.full_name}}</span>
+            <span style="font-variant: small-caps;">[new]</span>
+            {% else %}
+            <span>
+              {{r.full_name}}
+            </span>
+            {% endif %}
+          </td>
+          <td></td>
+          <td>
+            <a href="{{r.html_url}}">
+              <i class="far fa-folder-open mx-2"></i>              
+            </a>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% endif %}
+
+
+    <!-- removed repositories -->
+    {% if removed_repos %}
+    <h5 class="mt-5 text-bold">Revoked access to:</h5>
+
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th style="width: 5px"></th>
+          <th>Repository</th>
+          <th style="width: 100px"></th>
+          <th style="width: 120px"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in removed_repos %}
+        <tr>
+          <td><i class="fab fa-github mr-1"></i></td>
+          <td>{{r.full_name}}</td>
+          <td></td>
+          <td>
+            <a href="{{r.html_url}}">
+              <i class="far fa-folder-open mx-2"></i>              
+            </a>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% endif %}
+
+    <div class="container-sm text-center p-4 mt-5">
+      <div class="form-group pt-5 text-center d-inline">
+        <a type="button" href="{{webapp_url}}"
+          class="btn btn-primary text-bold" style="width: 175px">
+          Dashboard
+        </a>
+      </div>
+
+      <div class="form-group pt-5 text-center d-inline">
+        <a type="button" class="btn btn-primary text-bold" style="width: 175px"
+          href="/profile?currentView=githubSettingsTab">Settings</a>
+      </div>
+
+      <div class="form-group pt-5 text-center d-inline">
+        <a type="button" href="https://github.com/settings/installations/{{installation.id}}"
+          class="btn btn-primary text-bold" style="width: 175px">Manage</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+{% endblock body %}


### PR DESCRIPTION
This PR introduces a new callback endpoint for the LifeMonitor GitHub App. 

The endpoint provides:
* a feedback to confirm that the installation was successful;
* an overview of the user's repos where the GitHub App has been installed (with a link to easily jump to those repos on GitHub);
* three additional control buttons to jump to the LifeMonitor *Dashboard*, to the *GitHub App Global Settings* and to the App *administration page on GitHub* (to add/remove repos to the current installation or to completely uninstall the app from the user account.

![Screenshot 2022-11-14 at 16 00 24](https://user-images.githubusercontent.com/1832243/201695518-0b123c56-b351-4086-84f0-5ff46cf09821.png)

### "Settings" Button

![Screenshot 2022-11-14 at 16 37 45](https://user-images.githubusercontent.com/1832243/201701519-66ab8905-5853-4c55-b6bb-02475d707372.png)

### "Manage" Button
By clicking the **Manage** button the user will be redirected to the GitHub app administration page:

![Screenshot 2022-11-14 at 16 01 59](https://user-images.githubusercontent.com/1832243/201700526-f46b881e-0b10-4f6d-9c60-1b9df0e5812c.png)



(fix #253, #254)