### PR TITLE
Feature/User friendly rendering of automated checks list

### DIFF
--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -572,12 +572,17 @@ def workflows_delete(wf_uuid):
 
 
 @cached(timeout=Timeout.REQUEST)
-def workflows_get_issue_types(format="json", back=None):
-    issues = serializers.ListOfWorkflowIssueTypesSchema().dump(models.WorkflowRepositoryIssue.all())
-    if format == 'html':
-        return Response(render_template("api/issues.j2", issues=issues['items'], back_param=back),
-                        mimetype="text/html", status=200)
-    return issues
+def workflows_get_issue_types():
+    return serializers.ListOfWorkflowIssueTypesSchema().dump(models.WorkflowRepositoryIssue.all())
+
+
+@cached(timeout=Timeout.REQUEST)
+def workflows_get_issue_types_as_html(back=None):
+    return Response(
+        render_template(
+            "api/issues.j2", back_param=back,
+            issues=serializers.ListOfWorkflowIssueTypesSchema().dump(models.WorkflowRepositoryIssue.all())['items']),
+        mimetype="text/html", status=200)
 
 
 @cached(timeout=Timeout.REQUEST)

--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -24,7 +24,7 @@ import tempfile
 import connexion
 import lifemonitor.exceptions as lm_exceptions
 import werkzeug
-from flask import Response, request
+from flask import Response, request, render_template
 from lifemonitor.api import models, serializers
 from lifemonitor.api.services import LifeMonitor
 from lifemonitor.auth import (EventType, authorized, current_registry,
@@ -572,8 +572,12 @@ def workflows_delete(wf_uuid):
 
 
 @cached(timeout=Timeout.REQUEST)
-def workflows_get_issue_types():
-    return serializers.ListOfWorkflowIssueTypesSchema().dump(models.WorkflowRepositoryIssue.all())
+def workflows_get_issue_types(format="json", back=None):
+    issues = serializers.ListOfWorkflowIssueTypesSchema().dump(models.WorkflowRepositoryIssue.all())
+    if format == 'html':
+        return Response(render_template("api/issues.j2", issues=issues['items'], back_param=back),
+                        mimetype="text/html", status=200)
+    return issues
 
 
 @cached(timeout=Timeout.REQUEST)

--- a/lifemonitor/api/serializers.py
+++ b/lifemonitor/api/serializers.py
@@ -109,13 +109,13 @@ class WorkflowIssueTypeSchema(ResourceMetadataSchema):
     identifier = fields.String(attribute="identifier")
     name = fields.String(attribute="name")
     labels = fields.Method("get_labels")
-    depends_on = fields.String(attribute="get_depends_on")
+    depends_on = fields.Method("get_depends_on")
 
     def get_labels(self, issue: WorkflowRepositoryIssue):
         return issue.labels
 
     def get_depends_on(self, issue: WorkflowRepositoryIssue):
-        return [_.identifier for _ in issue.depends_on] if issue.depends_on else []
+        return [_.get_identifier() for _ in issue.depends_on] if issue.depends_on else []
 
 
 class ListOfWorkflowIssueTypesSchema(ListOfItems):

--- a/lifemonitor/templates/api/issues.j2
+++ b/lifemonitor/templates/api/issues.j2
@@ -1,0 +1,82 @@
+{% extends 'auth/base.j2' %}
+{% import 'auth/macros.j2' as macros %}
+
+{% block body_class %} login-page {% endblock %}
+
+{% block body_style %}
+height: auto;  
+padding: 20px;
+{% endblock %}
+
+
+{% block body %}
+
+    {{ macros.render_logo(style="max-width: 300px;", class="img-fluid logo text-center mx-5 mt-5") }}
+
+    <div class="font-weight-lighter mt-5 text-primary mb-4 text-center"
+      style="font-size: 2.5rem; line-height: 20px; width: 100%;">
+        <div class="text-center align-items-center">
+            <!--<div style="width: 34px; height: 100%; margin: auto;">
+                <i class="fas fa-exclamation-circle fa-lg"></i>
+            </div>-->
+            <div>Supported Checks</div>
+            <div class="float-right px-2 mt-n5">
+                <a href="/openapi.html" title="LifeMonitor API Explorer" target="_blank">                    
+                    <div class="col-12 text-center font-weight-light">
+                        <img src="{{ url_for('auth.static', filename='img/logo/openapi-custom-colors.svg') }}" width="90px">    
+                        <div class="ml-n4  text-center">
+                            <div class="mt-n1" style="font-family: 'Montserrat', sans-serif;">
+                                <div class="font-weight-bold" style="font-size: 1.2rem;">
+                                    <span class="m-1" style="letter-spacing: 2px; font-variant:">API</span>
+                                </div>
+                            </div>
+                            <div class="mt-n2" style="font-size: 0.8rem; margin-left: -2px;">explorer</div>
+                        </div>
+                    </div>                    
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <!-- Main content -->
+    <div class="container-fluid">
+
+        <!-- Back param -->
+        <div class="clearfix">
+            {% if back_param %}
+
+            <a href="{{ back_param }}" itle="Go back" >
+                <i class="fas fa-caret-left mx-1"></i>     
+                back
+            </a>
+            {% endif %}
+        </div>
+
+        <div class="card card-primary card-outline">
+            
+            <div class="card-body">                
+                {% for i in issues %}
+                    <div class="list-group-item list-group-item-action"  style="background: #1f8787; color: white;"
+                         data-toggle="collapse" href="#{{i.identifier}}" role="button" 
+                         aria-expanded="false" aria-controls="{{i.identifier}}" aria-pressed="false">
+                         <b>{{loop.index}}: {{ i.name }}</b>
+                    </div>
+                    <div class="collapse show" id="{{i.identifier}}">
+                        
+                        <div class="card card-body">
+                            <ul class="px-0" style="list-style-type: none;">
+                                <li><b>ID:</b> {{i.identifier}}</li>                                
+                                <li><b>Labels:</b> {{ i.labels | join(", ") }}</li>
+                                <li><b>Depends on:</b> {{ i.depends_on|join(", ") or "None"}}</li>
+                            </ul>
+                            <b>Description</b> 
+                            <div class="d-inline">{{ i.description|safe|join('')}}</div>
+                        </div>
+                    </div>
+                {% endfor %}                
+            </div>
+        </div>
+    </div>
+
+{% endblock %}
+<!-- body block -->

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -647,9 +647,6 @@ paths:
       tags: ["Workflows"]
       security:
         - {}
-      parameters:
-        - $ref: "#/components/parameters/format"
-        - $ref: "#/components/parameters/back"
       responses:
         "200":
           description: >
@@ -658,10 +655,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ListOfIssues"
-            text/html: 
+
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /workflows/issues.html:
+    get:
+      summary: List issue types
+      description: "Get information about the specified workflow"
+      x-openapi-router-controller: lifemonitor.api.controllers
+      operationId: "workflows_get_issue_types_as_html"
+      tags: ["Workflows"]
+      security:
+        - {}
+      parameters:
+        - $ref: "#/components/parameters/back"
+      responses:
+        "200":
+          description: >
+            List of issue types.
+          content:
+            text/html:
               schema:
                 type: string
-              
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -1648,7 +1670,6 @@ components:
       description: |
         A callback URL
       example: "https://lifemonitor.eu"
-    
 
   responses:
     NotFound:

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -647,6 +647,9 @@ paths:
       tags: ["Workflows"]
       security:
         - {}
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/back"
       responses:
         "200":
           description: >
@@ -655,6 +658,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ListOfIssues"
+            text/html: 
+              schema:
+                type: string
+              
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -1622,6 +1629,26 @@ components:
         type: string
       required: true
       example: 123e4567-e89b-12d3-a456-426614174000
+    format:
+      name: "format"
+      in: query
+      schema:
+        type: string
+        enum: [json, html]
+      # default: 'json' # not supported yet
+      description: |
+        `json` to get a JSON object; 
+        'html' to render the list of issues on a formatted HTML page
+      example: "html"
+    back:
+      name: "back"
+      in: query
+      schema:
+        type: string
+      description: |
+        A callback URL
+      example: "https://lifemonitor.eu"
+    
 
   responses:
     NotFound:


### PR DESCRIPTION
This PR addresses issue #248.

The endpoint `/workflows/issues` has been extended to support a new `format` parameter. It can accept two values: `json` (default) and `html`. When `format` is set to `html` the server returns a HTML page like:

![Screenshot 2022-11-15 at 15 26 57](https://user-images.githubusercontent.com/1832243/201944350-8a6f7503-0d41-438f-9e2f-6b92de39f1ff.png)

(fix #248)