### PR TITLE
Reorganize repository check modules

### DIFF
--- a/cli/client/issues.py
+++ b/cli/client/issues.py
@@ -68,7 +68,7 @@ def list(config):
     for idx in range(1, len(issues_list) + 1):
         i = issues_list[idx - 1]
         table.add_row(str(idx), i.get_identifier(), i.name,
-                      Syntax(i.description, "html"), ", ".join([_.__name__ for _ in i.depends_on]), ", ".join(i.labels))
+                      Syntax(i.description, "html"), ", ".join([_.get_identifier() for _ in i.depends_on]), ", ".join(i.labels))
     console.print(table)
 
 

--- a/lifemonitor/api/models/issues/__init__.py
+++ b/lifemonitor/api/models/issues/__init__.py
@@ -102,7 +102,9 @@ class WorkflowRepositoryIssue():
                 raise ValueError("Invalid issue type")
             class_name = issue_type.__name__
         logger.debug("Class Name: %r", class_name)
-        return to_snake_case(class_name)
+        # Get the parent package name (we use the package as a category)
+        tail_package = issue_type.__module__.rsplit('.', 1)[-1]
+        return f"{tail_package}.{class_name}"
 
     @classmethod
     def from_string(cls, issue_name: str) -> Type[WorkflowRepositoryIssue] | None:

--- a/lifemonitor/api/models/issues/__init__.py
+++ b/lifemonitor/api/models/issues/__init__.py
@@ -21,7 +21,6 @@
 from __future__ import annotations
 
 import abc
-import glob
 import inspect
 import logging
 import os
@@ -32,7 +31,6 @@ from typing import List, Optional, Type
 
 import networkx as nx
 from lifemonitor.api.models import repositories
-from lifemonitor.utils import to_snake_case
 
 # set module level logger
 logger = logging.getLogger(__name__)

--- a/lifemonitor/api/models/issues/general/experimental.py
+++ b/lifemonitor/api/models/issues/general/experimental.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2020-2022 CRS4
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import logging
+
+from lifemonitor.api.models.issues import WorkflowRepositoryIssue
+from lifemonitor.api.models.repositories import WorkflowRepository
+from .repo_layout import MissingROCrateFile
+
+# set module level logger
+logger = logging.getLogger(__name__)
+
+
+class OutdatedROCrateFile(WorkflowRepositoryIssue):
+    name = "RO-Crate metadata outdated"
+    description = "The <code>ro-crate-metadata.json</code> needs to be updated."
+    labels = ['invalid', 'bug']
+    depends_on = [MissingROCrateFile]
+
+    def check(self, repo: WorkflowRepository) -> bool:
+        return False

--- a/lifemonitor/api/models/issues/general/lm.py
+++ b/lifemonitor/api/models/issues/general/lm.py
@@ -41,5 +41,3 @@ class MissingLMConfigFile(WorkflowRepositoryIssue):
             self.add_change(config)
             return True
         return False
-
-

--- a/lifemonitor/api/models/issues/general/lm.py
+++ b/lifemonitor/api/models/issues/general/lm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022 CRS4
+# Copyright (c) 2020-2021 CRS4
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,19 +23,23 @@ from __future__ import annotations
 import logging
 
 from lifemonitor.api.models.issues import WorkflowRepositoryIssue
-from lifemonitor.api.models.issues.common.files.missing import \
-    MissingMetadataFile
 from lifemonitor.api.models.repositories import WorkflowRepository
 
 # set module level logger
 logger = logging.getLogger(__name__)
 
 
-class OutdatedMetadataFile(WorkflowRepositoryIssue):
-    name = "RO-Crate metadata outdated"
-    description = "The <code>ro-crate-metadata.json</code> needs to be updated."
-    labels = ['invalid', 'bug']
-    depends_on = [MissingMetadataFile]
+class MissingLMConfigFile(WorkflowRepositoryIssue):
+    name = "Missing LifeMonitor configuration file"
+    description = "No <code>lifemonitor.yaml</code> configuration file found on this repository.<br>"\
+        "The <code>lifemonitor.yaml</code> should be placed on the root of this repository."
+    labels = ['config', 'enhancement']
 
     def check(self, repo: WorkflowRepository) -> bool:
+        if repo.config is None:
+            config = repo.generate_config()
+            self.add_change(config)
+            return True
         return False
+
+

--- a/lifemonitor/api/models/issues/general/metadata.py
+++ b/lifemonitor/api/models/issues/general/metadata.py
@@ -23,9 +23,8 @@ from __future__ import annotations
 import logging
 
 from lifemonitor.api.models.issues import WorkflowRepositoryIssue
-from lifemonitor.api.models.issues.common.files.missing import \
-    MissingMetadataFile, MissingConfigFile
 from lifemonitor.api.models.repositories import WorkflowRepository
+from .repo_layout import MissingROCrateFile, MissingLMConfigFile
 
 # set module level logger
 logger = logging.getLogger(__name__)
@@ -35,7 +34,7 @@ class MissingWorkflowName(WorkflowRepositoryIssue):
     name = "Missing property name for Workflow RO-Crate"
     description = "No name defined for this workflow. <br>You can set the workflow name on the `ro-crate-metadata.yaml` or `lifemonitor.yaml` file"
     labels = ['invalid', 'bug']
-    depends_on = [MissingConfigFile, MissingMetadataFile]
+    depends_on = [MissingLMConfigFile, MissingROCrateFile]
 
     def check(self, repo: WorkflowRepository) -> bool:
         if repo.config.workflow_name:

--- a/lifemonitor/api/models/issues/general/metadata.py
+++ b/lifemonitor/api/models/issues/general/metadata.py
@@ -24,7 +24,8 @@ import logging
 
 from lifemonitor.api.models.issues import WorkflowRepositoryIssue
 from lifemonitor.api.models.repositories import WorkflowRepository
-from .repo_layout import MissingROCrateFile, MissingLMConfigFile
+
+from .repo_layout import RepositoryNotInitialised
 
 # set module level logger
 logger = logging.getLogger(__name__)
@@ -34,11 +35,11 @@ class MissingWorkflowName(WorkflowRepositoryIssue):
     name = "Missing property name for Workflow RO-Crate"
     description = "No name defined for this workflow. <br>You can set the workflow name on the `ro-crate-metadata.yaml` or `lifemonitor.yaml` file"
     labels = ['invalid', 'bug']
-    depends_on = [MissingLMConfigFile, MissingROCrateFile]
+    depends_on = [RepositoryNotInitialised]
 
     def check(self, repo: WorkflowRepository) -> bool:
         if repo.config.workflow_name:
             return False
-        if repo.metadata.main_entity_name:
+        if repo.metadata and repo.metadata.main_entity_name:
             return False
         return True

--- a/lifemonitor/api/models/issues/general/repo_layout.py
+++ b/lifemonitor/api/models/issues/general/repo_layout.py
@@ -24,30 +24,17 @@ import logging
 
 from lifemonitor.api.models.issues import WorkflowRepositoryIssue
 from lifemonitor.api.models.repositories import WorkflowRepository
+from .lm import MissingLMConfigFile
 
 # set module level logger
 logger = logging.getLogger(__name__)
 
 
-class MissingConfigFile(WorkflowRepositoryIssue):
-    name = "Missing config file"
-    description = "No <code>lifemonitor.yaml</code> configuration file found on this repository.<br>"\
-        "The <code>lifemonitor.yaml</code> should be placed on the root of this repository."
-    labels = ['config', 'enhancement']
-
-    def check(self, repo: WorkflowRepository) -> bool:
-        if repo.config is None:
-            config = repo.generate_config()
-            self.add_change(config)
-            return True
-        return False
-
-
-class NotInitialisedRepositoryIssue(WorkflowRepositoryIssue):
+class RepositoryNotInitialised(WorkflowRepositoryIssue):
     name = "Repository not intialised"
     description = "No workflow and crate metadata found on this repository."
     labels = ['invalid', 'enhancement', 'config']
-    depends_on = [MissingConfigFile]
+    depends_on = [MissingLMConfigFile]
 
     def check(self, repo: WorkflowRepository) -> bool:
         return repo.find_workflow() is None and repo.metadata is None
@@ -58,13 +45,13 @@ class MissingWorkflowFile(WorkflowRepositoryIssue):
     description = "No workflow found on this repository.<br>"\
         "You should place the workflow file (e.g., <code>.ga</code> file) according to the best practices ."
     labels = ['invalid', 'bug']
-    depends_on = [NotInitialisedRepositoryIssue]
+    depends_on = [RepositoryNotInitialised]
 
     def check(self, repo: WorkflowRepository) -> bool:
         return repo.find_workflow() is None
 
 
-class MissingMetadataFile(WorkflowRepositoryIssue):
+class MissingROCrateFile(WorkflowRepositoryIssue):
     name = "Missing RO-Crate metadata"
     description = "No <code>ro-crate-metadata.json</code> found on this repository.<br>"\
         "The <code>ro-crate-metadata.json</code> should be placed on the root of this repository."
@@ -79,11 +66,11 @@ class MissingMetadataFile(WorkflowRepositoryIssue):
         return False
 
 
-class MissingRoCrateWorkflowFile(WorkflowRepositoryIssue):
+class MissingROCrateWorkflowFile(WorkflowRepositoryIssue):
     name = "Missing RO-Crate workflow file"
     description = "The workflow file declared on RO-Crate metadata is missing in this repository."
     labels = ['invalid', 'bug']
-    depends_on = [MissingMetadataFile]
+    depends_on = [MissingROCrateFile]
 
     def check(self, repo: WorkflowRepository) -> bool:
         if repo.metadata:

--- a/lifemonitor/api/models/repositories/templates/__init__.py
+++ b/lifemonitor/api/models/repositories/templates/__init__.py
@@ -46,7 +46,7 @@ class WorkflowRepositoryTemplate(WorkflowRepository):
         if not local_path:
             local_path = tempfile.NamedTemporaryFile(dir='/tmp').name
         super().__init__(local_path, exclude=exclude)
-        self.name = name
+        self._name = name
         self._files = None
         self._data = data or {}
         self._dirty = True
@@ -119,7 +119,7 @@ class WorkflowRepositoryTemplate(WorkflowRepository):
         opts.update({
             'root': target_path,
         })
-        repo.generate_metadata(**self.data)
+        repo.generate_metadata(**opts)
         return repo
 
     def generate_metadata(self) -> WorkflowRepositoryMetadata:

--- a/lifemonitor/api/models/wizards/repository_template.py
+++ b/lifemonitor/api/models/wizards/repository_template.py
@@ -23,8 +23,8 @@ from __future__ import annotations
 import logging
 import os
 
-from lifemonitor.api.models.issues.common.files.missing import \
-    NotInitialisedRepositoryIssue
+from lifemonitor.api.models.issues.general.repo_layout import \
+    RepositoryNotInitialised
 from lifemonitor.api.models.repositories.github import GithubWorkflowRepository
 from lifemonitor.api.models.repositories.templates import \
     WorkflowRepositoryTemplate
@@ -79,7 +79,7 @@ class RepositoryTemplateWizard(Wizard):
     title = "Repository Template"
     description = ""
     labels = ['config']
-    issue = NotInitialisedRepositoryIssue
+    issue = RepositoryNotInitialised
 
     workflow_type = QuestionStep("Which type of workflow are we going to host on this repository?",
                                  description="",

--- a/lifemonitor/utils.py
+++ b/lifemonitor/utils.py
@@ -145,8 +145,9 @@ def to_snake_case(camel_str) -> str:
     :param camel_str:
     :return:
     """
-    pattern = re.compile(r'(?<!^)(?=[A-Z])')
-    return pattern.sub('_', "".join(camel_str.split())).lower()
+    # pattern = re.compile(r'(?<!^)(?=[A-Z])')
+    # return pattern.sub('_', "".join(camel_str.split())).lower()
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', camel_str).lower()
 
 
 def to_kebab_case(camel_str) -> str:

--- a/tests/unit/issues/test_missing_workflow.py
+++ b/tests/unit/issues/test_missing_workflow.py
@@ -22,8 +22,7 @@ import logging
 import os
 
 import pytest
-from lifemonitor.api.models.issues.common.files.missing import \
-    MissingWorkflowFile
+from lifemonitor.api.models.issues.general.repo_layout import MissingWorkflowFile
 from lifemonitor.api.models.repositories import ZippedWorkflowRepository
 from lifemonitor.api.models.repositories.local import LocalWorkflowRepository
 

--- a/tests/unit/issues/test_rocrate_metadata.py
+++ b/tests/unit/issues/test_rocrate_metadata.py
@@ -21,7 +21,7 @@
 import logging
 
 import pytest
-from lifemonitor.api.models.issues.general.metadata import MissingROCrateFile
+from lifemonitor.api.models.issues.general.repo_layout import MissingROCrateFile
 from lifemonitor.api.models.repositories import GithubWorkflowRepository
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/issues/test_rocrate_metadata.py
+++ b/tests/unit/issues/test_rocrate_metadata.py
@@ -21,8 +21,7 @@
 import logging
 
 import pytest
-from lifemonitor.api.models.issues.common.files.missing import \
-    MissingMetadataFile
+from lifemonitor.api.models.issues.general.metadata import MissingROCrateFile
 from lifemonitor.api.models.repositories import GithubWorkflowRepository
 
 logger = logging.getLogger(__name__)
@@ -36,11 +35,11 @@ def repository() -> GithubWorkflowRepository:
 
 
 @pytest.fixture
-def issue() -> MissingMetadataFile:
-    return MissingMetadataFile()
+def issue() -> MissingROCrateFile:
+    return MissingROCrateFile()
 
 
-def test_check_true(repository: GithubWorkflowRepository, issue: MissingMetadataFile):
+def test_check_true(repository: GithubWorkflowRepository, issue: MissingROCrateFile):
     logger.debug("Workflow RO-Crate: %r", repository)
 
     # detect workflow metadata
@@ -53,7 +52,7 @@ def test_check_true(repository: GithubWorkflowRepository, issue: MissingMetadata
     assert result is False, "Workflow RO-Crate should have the workflow file"
 
 
-def test_check_false(repository: GithubWorkflowRepository, issue: MissingMetadataFile):
+def test_check_false(repository: GithubWorkflowRepository, issue: MissingROCrateFile):
     logger.debug("Workflow RO-Crate: %r", repository)
 
     # detect workflow file


### PR DESCRIPTION
This PR proposes a solution for issue #246 by reorganizing automated repository check implementations into new modules.  The idea is to split the checks into the following categories:

* general.lm: things specific to LifeMonitor 
* general.metadata: metadata-related checks (e.g., RO-crate properties)
* general.repo_layout: general repository layout issues, such as missing metadata files or workflow files
* <one category per supported workflow type -- e.g., galaxy, snakemake)>

The `lifemonitor/api/models/issues` directory therefore takes the form:
```
./galaxy
./snakemake
./general
./general/metadata.py
./general/repo_layout.py
./general/experimental.py
./general/lm.py
./__init__.py
```

The PR changes the generation of check identifiers to use the module+class name rather than converting the class name to snake case (the automated conversion did not work very well).

The PR also proposes fixing for some small type annotation issues and a change to the check finding function (the original presented problems when relative imports were used).