### PR TITLE
Implement support for variations on repo config file name

### DIFF
--- a/lifemonitor/api/models/repositories/base.py
+++ b/lifemonitor/api/models/repositories/base.py
@@ -258,11 +258,11 @@ class WorkflowRepository():
 
     @property
     def config(self) -> WorkflowRepositoryConfig:
-        if not self._config:
-            if not os.path.exists(os.path.join(self.local_path, WorkflowRepositoryConfig.FILENAME)):
-                return None
-            else:
+        if self._config is None:
+            try:
                 self._config = WorkflowRepositoryConfig(self.local_path)
+            except ValueError:
+                pass
         return self._config
 
     def generate_config(self, ignore_existing=False) -> WorkflowFile:

--- a/lifemonitor/api/models/repositories/config.py
+++ b/lifemonitor/api/models/repositories/config.py
@@ -55,7 +55,7 @@ class WorkflowRepositoryConfig(RepositoryFile):
             p = f"{repo_path}/{head}lifemonitor.{ext}"
             if os.path.isfile(p):
                 return p
-        return None # file not found
+        return None  # file not found
 
     def load(self) -> dict:
         return yaml.safe_load(self.get_content())

--- a/lifemonitor/api/models/repositories/config.py
+++ b/lifemonitor/api/models/repositories/config.py
@@ -20,8 +20,10 @@
 
 from __future__ import annotations
 
+import itertools as it
 import logging
 import os
+import os.path
 from typing import Dict, List, Optional
 
 import lifemonitor.api.models as models
@@ -36,11 +38,24 @@ logger = logging.getLogger(__name__)
 
 class WorkflowRepositoryConfig(RepositoryFile):
 
-    FILENAME = "lifemonitor.yaml"
+    TEMPLATE_FILENAME = "lifemonitor.yaml.j2"
 
-    def __init__(self, path: str) -> None:
-        super().__init__(path, name=self.FILENAME, type='yaml')
-        self.__raw_data = None
+    def __init__(self, repo_path: str) -> None:
+        config_file = self._search_for_config_file(repo_path)
+        if config_file:
+            super().__init__(repo_path, name=config_file, type='yaml')
+            self.__raw_data = None
+        else:
+            logger.debug("Cannot find configuration file in repository %s", repo_path)
+            raise ValueError("cannot find configuration file in repository")
+
+    @classmethod
+    def _search_for_config_file(cls, repo_path: str) -> Optional[str]:
+        for head, ext in it.product(('', '.'), ('yml', 'yaml')):
+            p = f"{repo_path}/{head}lifemonitor.{ext}"
+            if os.path.isfile(p):
+                return p
+        return None # file not found
 
     def load(self) -> dict:
         return yaml.safe_load(self.get_content())
@@ -156,11 +171,11 @@ class WorkflowRepositoryConfig(RepositoryFile):
 
     @classmethod
     def new(cls, repository_path: str, workflow_title: str = "Workflow RO-Crate", public: bool = False, main_branch: str = "main") -> WorkflowRepositoryConfig:
-        tmpl = TemplateRepositoryFile(repository_path="lifemonitor/templates/repositories/base", name=f"{cls.FILENAME}.j2")
+        tmpl = TemplateRepositoryFile(repository_path="lifemonitor/templates/repositories/base", name=cls.TEMPLATE_FILENAME)
         registries = models.WorkflowRegistry.all()
         issue_types = models.WorkflowRepositoryIssue.all()
         os.makedirs(repository_path, exist_ok=True)
         tmpl.write(workflow_title=workflow_title, main_branch=main_branch, public=public,
                    issues=issue_types, registries=registries,
-                   output_file_path=os.path.join(repository_path, cls.FILENAME))
+                   output_file_path=os.path.join(repository_path, cls.TEMPLATE_FILENAME))
         return cls(path=repository_path)

--- a/lifemonitor/api/models/repositories/local.py
+++ b/lifemonitor/api/models/repositories/local.py
@@ -47,7 +47,9 @@ logger = logging.getLogger(__name__)
 
 class LocalWorkflowRepository(WorkflowRepository):
 
-    def __init__(self, local_path: str = None, exclude: List[str] = None) -> None:
+    def __init__(self,
+                 local_path: Optional[str] = None,
+                 exclude: Optional[List[str]] = None) -> None:
         super().__init__(local_path, exclude)
         self._transient_files = {'add': {}, 'remove': {}}
 
@@ -104,11 +106,11 @@ class LocalWorkflowRepository(WorkflowRepository):
             if self._file_key_(self._metadata.repository_file) not in self._transient_files['remove'] \
             else None
 
-    def find_file_by_pattern(self, search: str, path: str = None) -> RepositoryFile:
+    def find_file_by_pattern(self, search: str, path: Optional[str] = None) -> RepositoryFile:
         logger.warning("Searching file: %r %r", search, path)
         return next((f for f in self.files if re.search(search, f.name) and (not path or f.dir == path or f.dir == f"./{path}")), None)
 
-    def find_file_by_name(self, name: str, path: str = None) -> RepositoryFile:
+    def find_file_by_name(self, name: str, path: Optional[str] = None) -> RepositoryFile:
         logger.warning("Searching file: %r %r", name, path)
         return next((f for f in self.files if f.name == name and (not path or f.path == path or f.dir == f"./{path}")), None)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,8 @@ import shutil
 import string
 import uuid
 from collections.abc import Iterable
+from pathlib import Path
+from typing import Generator
 from unittest.mock import MagicMock
 
 import lifemonitor.db as lm_db
@@ -35,6 +37,8 @@ import pytest
 from lifemonitor import auth
 from lifemonitor.api.models import (TestingService, TestingServiceTokenManager,
                                     TestSuite, User)
+from lifemonitor.api.models.repositories import ZippedWorkflowRepository
+from lifemonitor.api.models.repositories import LocalWorkflowRepository
 from lifemonitor.api.services import LifeMonitor
 from lifemonitor.cache import cache, clear_cache
 from lifemonitor.utils import ClassManager, extract_zip
@@ -472,3 +476,13 @@ def mock_registry():
 @pytest.fixture
 def tmpdir(tmpdir):
     return pathlib.Path(tmpdir)
+
+
+@pytest.fixture
+def repository() -> Generator[LocalWorkflowRepository, None, None]:
+    crate_path = Path(__file__).parent / 'crates' / 'ro-crate-galaxy-sortchangecase.crate.zip'
+    repo = ZippedWorkflowRepository(crate_path)
+    try:
+        yield repo
+    finally:
+        repo.cleanup()

--- a/tests/crates/ro-crate-galaxy-sortchangecase.crate.zip
+++ b/tests/crates/ro-crate-galaxy-sortchangecase.crate.zip
@@ -1,0 +1,1 @@
+../config/data/ro-crate-galaxy-sortchangecase.crate.zip

--- a/tests/unit/api/models/repositories/test_config.py
+++ b/tests/unit/api/models/repositories/test_config.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2020-2022 CRS4
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from lifemonitor.api.models import repositories
+from lifemonitor.api.models.repositories import ZippedWorkflowRepository
+from lifemonitor.api.models.repositories.local import LocalWorkflowRepository
+from lifemonitor.api.models.repositories.config import WorkflowRepositoryConfig
+
+logger = logging.getLogger(__name__)
+
+
+cfg_file_contents = """
+name: "MyWorkflow"
+public: true
+issues:
+    checks: false
+"""
+
+
+def test_finding_config_file(repository : LocalWorkflowRepository):
+    with pytest.raises(ValueError):
+        cfg = WorkflowRepositoryConfig(repository.local_path)
+
+    for fname in ('.lifemonitor', 'lifemonitor'):
+        for ext in ('yml', 'yaml'):
+            cfg_file = Path(repository.local_path, f"{fname}.{ext}")
+            try:
+                with cfg_file.open(mode='w+') as f:
+                    f.write(cfg_file_contents)
+
+                # The WorkflowRepositoryConfig constructor will raise if it doesn't find a
+                # configuration file.
+                cfg = WorkflowRepositoryConfig(repository.local_path)
+                assert "MyWorkflow" == cfg.workflow_name
+            finally:
+                cfg_file.unlink()

--- a/tests/unit/api/models/repositories/test_config.py
+++ b/tests/unit/api/models/repositories/test_config.py
@@ -23,8 +23,6 @@ from pathlib import Path
 
 import pytest
 
-from lifemonitor.api.models import repositories
-from lifemonitor.api.models.repositories import ZippedWorkflowRepository
 from lifemonitor.api.models.repositories.local import LocalWorkflowRepository
 from lifemonitor.api.models.repositories.config import WorkflowRepositoryConfig
 
@@ -39,7 +37,7 @@ issues:
 """
 
 
-def test_finding_config_file(repository : LocalWorkflowRepository):
+def test_finding_config_file(repository: LocalWorkflowRepository):
     with pytest.raises(ValueError):
         cfg = WorkflowRepositoryConfig(repository.local_path)
 

--- a/tests/unit/issues/crates/ro-crate-galaxy-sortchangecase.crate.zip
+++ b/tests/unit/issues/crates/ro-crate-galaxy-sortchangecase.crate.zip
@@ -1,1 +1,0 @@
-../../../config/data/ro-crate-galaxy-sortchangecase.crate.zip

--- a/tests/unit/issues/test_missing_workflow.py
+++ b/tests/unit/issues/test_missing_workflow.py
@@ -19,12 +19,10 @@
 # SOFTWARE.
 
 import logging
-import os
 
 import pytest
-from lifemonitor.api.models.issues.common.files.missing import \
-    MissingWorkflowFile
-from lifemonitor.api.models.repositories import ZippedWorkflowRepository
+
+from lifemonitor.api.models.issues.common.files.missing import MissingWorkflowFile
 from lifemonitor.api.models.repositories.local import LocalWorkflowRepository
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/issues/test_missing_workflow.py
+++ b/tests/unit/issues/test_missing_workflow.py
@@ -31,18 +31,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def crates_path() -> str:
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), 'crates')
-
-
-@pytest.fixture
-def repository(crates_path) -> LocalWorkflowRepository:
-    repo = ZippedWorkflowRepository(
-        os.path.join(crates_path, 'ro-crate-galaxy-sortchangecase.crate.zip'))
-    return repo
-
-
-@pytest.fixture
 def issue() -> MissingWorkflowFile:
     return MissingWorkflowFile()
 


### PR DESCRIPTION
This PR resolves issue #259.  It implements support for naming the repository configuration file `.lifemonitor.yml`, `.lifemonitor.yaml`, `lifemonitor.yml`, `lifemonitor.yaml`.

