### PR TITLE
update serialisation of {workflow, suite} status property 

### DIFF
--- a/lifemonitor/api/serializers.py
+++ b/lifemonitor/api/serializers.py
@@ -452,7 +452,7 @@ class WorkflowVersionListItem(WorkflowSchema):
         try:
             result = {
                 "aggregate_test_status": workflow.latest_version.status.aggregated_status,
-                "latest_build": self.get_latest_build(workflow)
+                "latest_builds": self.get_latest_builds(workflow)
             }
             reason = format_availability_issues(workflow.latest_version.status)
             if reason:
@@ -488,12 +488,13 @@ class WorkflowVersionListItem(WorkflowSchema):
                 logger.exception(e)
             return None
 
-    def get_latest_build(self, workflow):
+    def get_latest_builds(self, workflow):
         try:
             latest_builds = workflow.latest_version.status.latest_builds
+            builds = []
             if latest_builds and len(latest_builds) > 0:
-                return BuildSummarySchema(exclude=('meta', 'links')).dump(latest_builds[0])
-            return None
+                builds.append(BuildSummarySchema(exclude=('meta', 'links')).dump(latest_builds[0]))
+            return builds
         except Exception as e:
             logger.debug(e)
             return None

--- a/lifemonitor/api/serializers.py
+++ b/lifemonitor/api/serializers.py
@@ -621,7 +621,7 @@ class SuiteStatusSchema(ResourceMetadataSchema):
         model = models.TestSuite
 
     suite_uuid = fields.String(attribute="uuid")
-    status = fields.Method("get_aggregated_status")
+    aggregate_test_status = fields.Method("get_aggregate_status")
     latest_builds = fields.Method("get_builds")
     reason = fields.Method("get_reason")
     _errors = []
@@ -643,7 +643,7 @@ class SuiteStatusSchema(ResourceMetadataSchema):
         except Exception as e:
             return str(e)
 
-    def get_aggregated_status(self, suite):
+    def get_aggregate_status(self, suite):
         try:
             return suite.status.aggregated_status
         except Exception as e:

--- a/lifemonitor/static/src/package.json
+++ b/lifemonitor/static/src/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lifemonitor",
     "description": "Workflow Testing Service",
-    "version": "0.8.0",
+    "version": "0.9.0-dev",
     "license": "MIT",
     "author": "CRS4",
     "main": "../dist/js/lifemonitor.min.js",

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -2424,9 +2424,11 @@ components:
                     properties:
                       aggregate_test_status:
                         $ref: "#/components/schemas/AggregateTestStatus"
-                      latest_build:
-                        description: "The most recent build on some test instance"
-                        $ref: "#/components/schemas/BuildSummary"
+                      latest_builds:
+                        description: "The most recent builds on some test instances"
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BuildSummary"                          
                         nullable: true
                   versions:
                     nullable: true

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -2428,7 +2428,7 @@ components:
                         description: "The most recent builds on some test instances"
                         type: array
                         items:
-                          $ref: "#/components/schemas/BuildSummary"                          
+                          $ref: "#/components/schemas/BuildSummary"
                         nullable: true
                   versions:
                     nullable: true

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -1049,7 +1049,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/WorkflowStatus"
+                $ref: "#/components/schemas/WorkflowVersionStatus"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -2456,52 +2456,6 @@ components:
           required:
             - items
 
-    WorkflowStatus:
-      allOf:
-        - $ref: "#/components/schemas/Workflow"
-        - type: object
-          properties:
-            version:
-              $ref: "#/components/schemas/WorkflowVersion"
-            aggregate_test_status:
-              $ref: "#/components/schemas/AggregateTestStatus"
-            latest_builds:
-              description: "Latest builds, one for each test instance"
-              type: array
-              items:
-                $ref: "#/components/schemas/BuildSummary"
-            reason:
-              description: "Reason why the status is unavailable"
-              type: string
-              nullable: true
-          required:
-            - aggregate_test_status
-            - version
-
-    WorkflowVersionStatus:
-      allOf:
-        - type: object
-          properties:
-            version:
-              $ref: "#/components/schemas/WorkflowVersion"
-            workflow:
-              $ref: "#/components/schemas/Workflow"
-            aggregate_test_status:
-              $ref: "#/components/schemas/AggregateTestStatus"
-            latest_builds:
-              description: "Latest builds, one for each test instance"
-              type: array
-              items:
-                $ref: "#/components/schemas/BuildSummary"
-            reason:
-              description: "Reason why the status is unavailable"
-              type: string
-              nullable: true
-          required:
-            - version
-            - workflow
-            - aggregate_test_status
-
     AggregateTestStatus:
       type: string
       enum:
@@ -2509,6 +2463,34 @@ components:
         - "some_passing"
         - "all_failing"
         - "not_available"
+
+    EntityTestStatus:
+      type: object
+      properties:
+        aggregate_test_status:
+          $ref: "#/components/schemas/AggregateTestStatus"
+        latest_builds:
+          description: "Latest builds, one for each test instance"
+          type: array
+          items:
+            $ref: "#/components/schemas/BuildSummary"
+        reason:
+          description: "Reason why the status is unavailable"
+          type: string
+          nullable: true
+
+    WorkflowVersionStatus:
+      allOf:
+        - $ref: "#/components/schemas/Workflow"
+        - $ref: "#/components/schemas/EntityTestStatus"
+          required:
+            - aggregate_test_status
+        - type: object
+          properties:
+            version:
+              $ref: "#/components/schemas/WorkflowVersion"
+          required:
+            - version
 
     WorkflowTestingROCrate:
       type: object
@@ -2563,7 +2545,7 @@ components:
           required:
             - uuid
             - instances
-        - $ref: "#/components/schemas/TestSuiteStatusProperties"
+        - $ref: "#/components/schemas/EntityTestStatus"
 
     ListOfTestSuite:
       type: object
@@ -2575,21 +2557,6 @@ components:
       required:
         - items
 
-    TestSuiteStatusProperties:
-      type: object
-      properties:
-        aggregate_test_status:
-          $ref: "#/components/schemas/AggregateTestStatus"
-        latest_builds:
-          type: array
-          items:
-            $ref: "#/components/schemas/BuildSummary"
-        reason:
-          description: Reason why the status is unavailable
-          type: string
-          example: "Unreachable testing service"
-          nullable: true
-
     TestSuiteStatus:
       allOf:
         - type: object
@@ -2600,9 +2567,7 @@ components:
               example: e3208b02-69b6-4e32-a3dc-b93967d30e2c
           required:
             - suite_uuid
-        - $ref: "#/components/schemas/TestSuiteStatusProperties"
-          required:
-            - aggregate_test_status
+        - $ref: "#/components/schemas/EntityTestStatus"
 
     BuildStatus:
       type: string

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -3,7 +3,7 @@
 openapi: "3.0.0"
 
 info:
-  version: "0.8.0"
+  version: "0.9.0-dev"
   title: "Life Monitor API"
   description: |
     *Workflow sustainability service*
@@ -18,7 +18,7 @@ info:
 servers:
   - url: /
     description: >
-      Version 0.8.0 of API.
+      Version 0.9.0-dev of API.
 
 tags:
   - name: Registries

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -2578,7 +2578,7 @@ components:
     TestSuiteStatusProperties:
       type: object
       properties:
-        status:
+        aggregate_test_status:
           $ref: "#/components/schemas/AggregateTestStatus"
         latest_builds:
           type: array

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -2602,7 +2602,7 @@ components:
             - suite_uuid
         - $ref: "#/components/schemas/TestSuiteStatusProperties"
           required:
-            - status
+            - aggregate_test_status
 
     BuildStatus:
       type: string

--- a/tests/integration/api/controllers/test_suites.py
+++ b/tests/integration/api/controllers/test_suites.py
@@ -77,7 +77,7 @@ def test_get_suite_status(app_client, client_auth_method, user1, user1_auth, val
     logger.debug("Response data: %r", data)
     # redundant check: the validation is performed by the connexion framework
     assert data['suite_uuid'] == str(suite.uuid), "Invalid UUID"
-    for p in ["status", "latest_builds"]:
+    for p in ["aggregate_test_status", "latest_builds"]:
         assert p in data, f"Missing required property {p}"
 
 

--- a/tests/unit/api/controllers/test_suites.py
+++ b/tests/unit/api/controllers/test_suites.py
@@ -146,7 +146,7 @@ def test_get_suite_status_by_user(m, request_context, no_cache, mock_user):
     m.get_suite.assert_called_once()
     assert isinstance(response, dict), "Unexpected result type"
     logger.debug("The response: %r", response)
-    for p in ["latest_builds", "suite_uuid", "status"]:
+    for p in ["latest_builds", "suite_uuid", "aggregate_test_status"]:
         assert p in response, f"Property {p} not found on response"
 
 
@@ -168,9 +168,9 @@ def test_get_suite_status_by_user_rate_limit_exceeded(lm, mock_user, rate_limit_
     response = controllers.suites_get_status(suite.uuid)
     lm.get_suite.assert_called_once()
     logger.info(response)
-    for p in ["latest_builds", "suite_uuid", "status"]:
+    for p in ["latest_builds", "suite_uuid", "aggregate_test_status"]:
         assert p in response, f"Property {p} not found on response"
-    assert response['status'] == 'not_available'
+    assert response['aggregate_test_status'] == 'not_available'
 
 
 @patch("lifemonitor.api.controllers.lm")
@@ -194,7 +194,7 @@ def test_get_suite_status_by_registry(m, request_context, no_cache, mock_registr
     m.get_registry_workflow_version.assert_called_once()
     assert isinstance(response, dict), "Unexpected result type"
     logger.debug("The response: %r", response)
-    for p in ["latest_builds", "suite_uuid", "status"]:
+    for p in ["latest_builds", "suite_uuid", "aggregate_test_status"]:
         assert p in response, f"Property {p} not found on response"
 
 
@@ -215,9 +215,9 @@ def test_get_suite_status_by_registry_rate_limit_exceeded(lm, request_context, m
     response = controllers.suites_get_status(suite.uuid)
     lm.get_suite.assert_called_once()
     logger.info(response)
-    for p in ["latest_builds", "suite_uuid", "status"]:
+    for p in ["latest_builds", "suite_uuid", "aggregate_test_status"]:
         assert p in response, f"Property {p} not found on response"
-    assert response['status'] == 'not_available'
+    assert response['aggregate_test_status'] == 'not_available'
 
 
 @patch("lifemonitor.api.controllers.lm")


### PR DESCRIPTION
* fix serialisation of the workflow `status` property nested in the `/workflows` response. The old implementation returns only the latest build instead of all the "latest builds" (i.e., the latest build of each test instance of each test suite)
* rename `status` property of test suite to `aggregate_test_status`