### PR TITLE
fix CLI to execute issue checks

### DIFF
--- a/cli/client/issues.py
+++ b/cli/client/issues.py
@@ -52,7 +52,7 @@ console = Console(theme=custom_theme)
 error_console = Console(stderr=True, style="bold red")
 
 repository_arg = click.argument('repository', type=str, default=".")
-output_path_arg = click.option('-o', '--output-path', type=click.Path(file_okay=False), default=None)
+output_path_arg = click.argument('output-path', type=click.Path(file_okay=False))
 
 
 @click.group(name="issues", help="Tools to develop and check issue types")
@@ -108,11 +108,11 @@ def get(config, issue_number):
 @output_path_arg
 @click.pass_obj
 # @with_appcontext
-def check(config, repository, output_path=None):
+def check(config, repository, output_path):
     try:
         init_output_path(output_path=output_path)
         repo = get_repository(repository, local_path=output_path)
-        result = repo.check(repository)
+        result = repo.check()
         # Configure Table
         table = Table(title=f"Check Issue Report of Repo [bold]{repository}[/bold]",
                       style="bold", expand=True)

--- a/cli/client/utils.py
+++ b/cli/client/utils.py
@@ -40,15 +40,17 @@ def is_url(value):
         return False
 
 
-def get_repository(repository: str, local_path: str = None):
+def get_repository(repository: str, local_path: str):
     assert repository, repository
     if is_url(repository):
         remote_repo_url = repository
         if remote_repo_url.endswith('.git'):
-            return GithubWorkflowRepository.from_url(remote_repo_url, auto_cleanup=True, local_path=local_path)
+            return GithubWorkflowRepository.from_url(remote_repo_url, auto_cleanup=False, local_path=local_path)
     else:
-        return LocalWorkflowRepository(repository)
-    return ValueError("Repository type not supported")
+        local_copy_path = os.path.join(local_path, os.path.basename(repository))
+        shutil.copytree(repository, local_copy_path)
+        return LocalWorkflowRepository(local_copy_path)
+    raise ValueError("Repository type not supported")
 
 
 def init_output_path(output_path):

--- a/lifemonitor/api/models/issues/__init__.py
+++ b/lifemonitor/api/models/issues/__init__.py
@@ -37,6 +37,7 @@ from lifemonitor.api.models import repositories
 # set module level logger
 logger = logging.getLogger(__name__)
 
+ROOT_ISSUE = 'r'
 
 class IssueMessage:
 
@@ -187,9 +188,8 @@ def load_issue(issue_file) -> List[Type[WorkflowRepositoryIssue]]:
     return issues.values()
 
 
-def find_issue_types(path: Optional[str] = None) -> List[Type[WorkflowRepositoryIssue]]:
+def get_issue_graph(path: Optional[str] = None) -> nx.DiGraph:
     errors = []
-    issues = {}
     g = nx.DiGraph()
     base_path = Path(path) if path else Path(__file__).parent
 
@@ -209,13 +209,12 @@ def find_issue_types(path: Optional[str] = None) -> List[Type[WorkflowRepository
                     and inspect.getmodule(obj) == mod \
                     and obj != WorkflowRepositoryIssue \
                         and issubclass(obj, WorkflowRepositoryIssue):
-                    issues[obj.__name__] = obj
                     dependencies = getattr(obj, 'depends_on', None)
                     if not dependencies or len(dependencies) == 0:
-                        g.add_edge('r', obj.__name__)
+                        g.add_edge(ROOT_ISSUE, obj)
                     else:
                         for dep in dependencies:
-                            g.add_edge(dep.__name__, obj.__name__)
+                            g.add_edge(dep, obj)
         except ModuleNotFoundError as e:
             logger.exception(e)
             logger.error("ModuleNotFoundError: Unable to load module %s", m)
@@ -224,10 +223,11 @@ def find_issue_types(path: Optional[str] = None) -> List[Type[WorkflowRepository
         logger.error("** There were some errors loading application modules.**")
         if logger.isEnabledFor(logging.DEBUG):
             logger.error("** Unable to load issues from %s", ", ".join(errors))
-    logger.debug("Issues: %r", [_.__name__ for _ in issues.values()])
-    sorted_issues = [issues[_] for _ in nx.dfs_preorder_nodes(g, source='r') if _ != 'r']
-    logger.debug("Sorted issues: %r", [_.__name__ for _ in sorted_issues])
-    return sorted_issues
+    return g
+
+
+def find_issue_types(path: Optional[str] = None) -> List[Type[WorkflowRepositoryIssue]]:
+    return [i for i in get_issue_graph(path).nodes if i != ROOT_ISSUE]
 
 
 __all__ = ["WorkflowRepositoryIssue"]

--- a/lifemonitor/api/models/issues/__init__.py
+++ b/lifemonitor/api/models/issues/__init__.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 
 ROOT_ISSUE = 'r'
 
+
 class IssueMessage:
 
     class TYPE(Enum):

--- a/lifemonitor/api/models/issues/general/metadata.py
+++ b/lifemonitor/api/models/issues/general/metadata.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class MissingWorkflowName(WorkflowRepositoryIssue):
-    name = "Missing property name for Workflow RO-Crate"
+    name = "Missing workflow name in metadata"
     description = "No name defined for this workflow. <br>You can set the workflow name on the `ro-crate-metadata.yaml` or `lifemonitor.yaml` file"
     labels = ['invalid', 'bug']
     depends_on = [RepositoryNotInitialised]

--- a/lifemonitor/api/models/issues/general/repo_layout.py
+++ b/lifemonitor/api/models/issues/general/repo_layout.py
@@ -24,7 +24,6 @@ import logging
 
 from lifemonitor.api.models.issues import WorkflowRepositoryIssue
 from lifemonitor.api.models.repositories import WorkflowRepository
-from .lm import MissingLMConfigFile
 
 # set module level logger
 logger = logging.getLogger(__name__)
@@ -34,7 +33,6 @@ class RepositoryNotInitialised(WorkflowRepositoryIssue):
     name = "Repository not intialised"
     description = "No workflow and crate metadata found on this repository."
     labels = ['invalid', 'enhancement', 'config']
-    depends_on = [MissingLMConfigFile]
 
     def check(self, repo: WorkflowRepository) -> bool:
         return repo.find_workflow() is None and repo.metadata is None

--- a/lifemonitor/api/models/repositories/base.py
+++ b/lifemonitor/api/models/repositories/base.py
@@ -32,7 +32,6 @@ from typing import Dict, List, Optional, Tuple
 import git
 import giturlparse
 import lifemonitor.api.models.issues as issues
-import networkx as nx
 import requests
 from lifemonitor.api.models.repositories.config import WorkflowRepositoryConfig
 from lifemonitor.exceptions import IllegalStateException, LifeMonitorException

--- a/lifemonitor/api/models/repositories/base.py
+++ b/lifemonitor/api/models/repositories/base.py
@@ -172,10 +172,10 @@ class WorkflowRepository():
         issue_graph = issues.get_issue_graph()
 
         visited = set()
-        queue = [i for i in issue_graph.neighbors('r')
+        queue = [i for i in issue_graph.neighbors(issues.ROOT_ISSUE)
                  if self._issue_name_included(i.__name__, include, exclude)]
         while queue:
-            issue_type = queue.pop(0)
+            issue_type = queue.pop()
             if issue_type not in visited:
                 issue = issue_type()
                 failed = issue.check(self)

--- a/lifemonitor/api/models/repositories/base.py
+++ b/lifemonitor/api/models/repositories/base.py
@@ -32,6 +32,7 @@ from typing import Dict, List, Optional, Tuple
 import git
 import giturlparse
 import lifemonitor.api.models.issues as issues
+import networkx as nx
 import requests
 from lifemonitor.api.models.repositories.config import WorkflowRepositoryConfig
 from lifemonitor.exceptions import IllegalStateException, LifeMonitorException
@@ -153,28 +154,48 @@ class WorkflowRepository():
     def contains(self, file: RepositoryFile) -> bool:
         return self.__contains__(self.files, file)
 
+    @staticmethod
+    def _issue_name_included(issue_name: str,
+                             include_list: List[str] | None = None,
+                             exclude_list: List[str] | None = None) -> bool:
+        if include_list and (issue_name in [to_camel_case(_) for _ in include_list]):
+            return True
+
+        if exclude_list is None:
+            return True
+
+        return issue_name not in [to_camel_case(_) for _ in exclude_list]
+
     def check(self, fail_fast: bool = True,
               include=None, exclude=None) -> IssueCheckResult:
         found_issues = []
-        checked = []
-        for issue_type in issues.find_issue_types():
-            if (not exclude or issue_type.__name__ not in [to_camel_case(_) for _ in exclude]) or \
-                    (not include or issue_type.__name__ in [to_camel_case(_) for _ in include]):
+        issue_graph = issues.get_issue_graph()
+
+        visited = set()
+        queue = [i for i in issue_graph.neighbors('r')
+                 if self._issue_name_included(i.__name__, include, exclude)]
+        while queue:
+            issue_type = queue.pop(0)
+            if issue_type not in visited:
                 issue = issue_type()
-                to_be_solved = issue.check(self)
-                checked.append(issue)
-                if to_be_solved:
+                failed = issue.check(self)
+                visited.add(issue_type)
+                if not failed:
+                    neighbors = [i for i in issue_graph.neighbors(issue_type)
+                                 if self._issue_name_included(i.__name__, include, exclude)]
+                    queue.extend(neighbors)
+                else:
                     found_issues.append(issue)
                     if fail_fast:
                         break
-        return IssueCheckResult(self, checked, found_issues)
+        return IssueCheckResult(self, list(visited), found_issues)
 
     @classmethod
     def __contains__(cls, files, file) -> bool:
         return cls.__find_file__(files, file) is not None
 
     @classmethod
-    def __find_file__(cls, files, file) -> RepositoryFile:
+    def __find_file__(cls, files, file) -> RepositoryFile | None:
         for f in files:
             if f == file or (f.name == file.name and f.dir == file.dir):
                 return f

--- a/lifemonitor/api/models/repositories/config.py
+++ b/lifemonitor/api/models/repositories/config.py
@@ -189,7 +189,7 @@ class WorkflowRepositoryConfig(RepositoryFile):
     @classmethod
     def new(cls, repository_path: str, workflow_title: str = "Workflow RO-Crate", public: bool = False, main_branch: str = "main") -> WorkflowRepositoryConfig:
         tmpl = TemplateRepositoryFile(repository_path="lifemonitor/templates/repositories/base", name=cls.TEMPLATE_FILENAME)
-        registries = models.WorkflowRegistry.all()
+        registries = ["wfhub", "wfhubdev"]
         issue_types = models.WorkflowRepositoryIssue.all()
         os.makedirs(repository_path, exist_ok=True)
         tmpl.write(workflow_title=workflow_title, main_branch=main_branch, public=public,

--- a/lifemonitor/api/models/repositories/files/workflows/__init__.py
+++ b/lifemonitor/api/models/repositories/files/workflows/__init__.py
@@ -35,10 +35,10 @@ logger = logging.getLogger(__name__)
 
 class WorkflowFile(RepositoryFile):
 
-    __workflow_types__: Dict[str, Type] = None
+    __workflow_types__: Dict[str, Type] | None = None
 
-    def __init__(self, repository_path: str, name: str, type: str = None, dir: str = ".",
-                 content=None, raw_file: RepositoryFile = None) -> None:
+    def __init__(self, repository_path: str, name: str, type: str | None = None, dir: str = ".",
+                 content=None, raw_file: RepositoryFile | None = None) -> None:
         super().__init__(repository_path, name, type, dir, content)
         self._raw_file = raw_file
 
@@ -53,11 +53,11 @@ class WorkflowFile(RepositoryFile):
         return super().get_content(binary_mode=binary_mode)
 
     @property
-    def raw_file(self) -> RepositoryFile:
+    def raw_file(self) -> RepositoryFile | None:
         return self._raw_file
 
     @classmethod
-    def get_workflow_extensions(cls, workflow_type: str) -> Set[str]:
+    def get_workflow_extensions(cls, workflow_type: str) -> Set[str] | None:
         try:
             return {_[1] for _ in cls.__get_workflow_types__()[workflow_type].__get_file_patterns__()}
         except AttributeError:
@@ -78,13 +78,13 @@ class WorkflowFile(RepositoryFile):
                    dir=file.dir, content=file._content, raw_file=file)
 
     @classmethod
-    def __get_file_patterns__(cls, subtype: Type = None) -> Tuple[Tuple[str, str, str]]:
+    def __get_file_patterns__(cls, subtype: Type = None) -> Tuple[Tuple[str, str, str]] | None:
         return getattr(subtype or cls, "FILE_PATTERNS", None)
 
     @classmethod
-    def is_workflow(cls, file: RepositoryFile) -> WorkflowFile:
+    def is_workflow(cls, file: RepositoryFile) -> WorkflowFile | None:
         if not file:
-            return False
+            return None
 
         subtypes = (cls,)
         if cls == WorkflowFile:
@@ -104,7 +104,7 @@ class WorkflowFile(RepositoryFile):
                     if p_dir and p_dir != f_dir:
                         continue
                     return subtype.__from_file__(file)
-        return False
+        return None
 
     @classmethod
     def __get_workflow_types__(cls) -> Dict[str, Type]:

--- a/lifemonitor/templates/repositories/base/.lifemonitor.yaml.j2
+++ b/lifemonitor/templates/repositories/base/.lifemonitor.yaml.j2
@@ -44,10 +44,10 @@ push:
     #   lifemonitor_instance: development   # uncomment to use the 'development' instance of LifeMonitor
     #                                       # (the 'production' instance is used by default)
     - name: "v*.*.*"
-      update_registries: [{{registries|join(', ', attribute="client_name")}}]
+      update_registries: [{{registries|join(', ')}}]
       enable_notifications: true
       # lifemonitor_instance: development
     - name: "*.*.*"
-      update_registries: [{{registries|join(', ', attribute="client_name")}}]
+      update_registries: [{{registries|join(', ')}}]
       enable_notifications: true
       # lifemonitor_instance: development


### PR DESCRIPTION
This PR makes some changes to the CLI path for executing issue checks. It fixes some small problems which kept the functionality from running. It also avoids failing fast, so that multiple unrelated checks can be executed in the same run. Finally, it includes some small fixes to type hints.