### PR TITLE
Fix access to missing repo configuration

### DIFF
--- a/lifemonitor/api/models/issues/general/metadata.py
+++ b/lifemonitor/api/models/issues/general/metadata.py
@@ -38,7 +38,7 @@ class MissingWorkflowName(WorkflowRepositoryIssue):
     depends_on = [RepositoryNotInitialised]
 
     def check(self, repo: WorkflowRepository) -> bool:
-        if repo.config.workflow_name:
+        if repo.config and repo.config.workflow_name:
             return False
         if repo.metadata and repo.metadata.main_entity_name:
             return False


### PR DESCRIPTION
Fixes the MissingWorkflowName check so that it verifies that the repository configuration object exists before checking for a workflow name.