### PR TITLE
Pass repo_url when generating github repo metadata

### DIFF
--- a/lifemonitor/api/models/repositories/github.py
+++ b/lifemonitor/api/models/repositories/github.py
@@ -303,7 +303,7 @@ class InstallationGithubWorkflowRepository(GithubRepository, WorkflowRepository)
                                f"'{self.local_repo._local_path}' will not be deleted")
             else:
                 self.cleanup()
-        return self.local_repo.generate_metadata()
+        return self.local_repo.generate_metadata(repo_url=self.html_url)
 
     def generate_config(self, ignore_existing=False) -> WorkflowRepositoryConfig:
         current_config = self.config


### PR DESCRIPTION
I think this should fix the problem whereby the RO-crate metadata generated by the LM github app doesn't contain the github action and test definition.  This change should cause repo2rocrate to be passed the repo_url argument, and thus detect the additional metadata.