### PR TITLE
fixup: set file permissions in Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,7 @@ dev:
 	$(eval LM_MODE=dev)
 
 certs:
-	@# Generate certificates if they do not exist \
-	if ! [[ -f "certs/lm.key" && -f "certs/lm.key" && -f "certs/lifemonitor.ca.crt" ]]; then \
+	@if ! [[ -f "certs/lm.key" && -f "certs/lm.key" && -f "certs/lifemonitor.ca.crt" ]]; then \
 	  printf "\n$(bold)Generating certificates...$(reset)\n" ; \
 	  mkdir -p certs && \
 	  ./utils/certs/gencerts.sh && \
@@ -119,8 +118,7 @@ certs:
 	  printf "\n$(done)\n"; \
 	else \
 	  echo "$(yellow)WARNING: Using existing certificates$(reset)" ; \
-	fi
-	@# Generate JWT keys if they do not exist \
+	fi ;\
 	if ! [[ -f "certs/jwt-key" && -f "certs/jwt-key.pub" ]]; then \
 	  printf "\n$(bold)Generating JWT keys...$(reset)\n" ; \
 	  openssl genrsa -out certs/jwt-key 4096 ; \

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ ro_crates: interaction_experiments/data/crates
 
 
 permissions: certs
-	chmod a+rx \
+	@chmod a+rx \
 		certs \
 		&& \
 	chmod a+r \


### PR DESCRIPTION
The various `start*` Makefile targets start docker-compose definitions which mount files or directories in Docker containers.  These mounts don't work as expected if the files have strict permissions.

This PR adds a Makefile target that sets world-readable permissions for the relevant files.

Note:  The branch for this PR is based on the branch fix/missing-ifconfig (PR #332).  Merge that one first.