### PR TITLE
fix: correct config variable used for timeout of service connections

### DIFF
--- a/lifemonitor/utils.py
+++ b/lifemonitor/utils.py
@@ -233,7 +233,7 @@ def validate_url(url: str) -> bool:
 def is_service_alive(url: str, timeout: Optional[int] = None) -> bool:
     try:
         try:
-            timeout = timeout or flask.current_app.config.get("SERVICE_ALIVE_TIMEOUT", 1)
+            timeout = timeout or flask.current_app.config.get("SERVICE_AVAILABILITY_TIMEOUT", 1)
         except Exception:
             timeout = 1
         response = requests.get(url, timeout=timeout)


### PR DESCRIPTION
This PR corrects the name of the configuration variable used to set the connection timeout used when contacting external services.