### PR TITLE
build(pip): pin SQLAlchemy to 1.4.41

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ snakemake==6.13.1
 networkx~=3.1.0
 rich~=13.4.1
 rocrate==0.8.0
-SQLAlchemy~=1.4.48
+SQLAlchemy~=1.4.41
 wheel~=0.40.0
 Werkzeug~=2.2.3
 repo2rocrate~=0.1.2


### PR DESCRIPTION
Downgrade `SQLAlchemy` to **1.4.41** to fix a conflict with `sqlmodel 0.8.0`, which requires SQLAlchemy  <= **1.4.41**.