### PR TITLE
fix: improve identification of workflow submitter

### DIFF
--- a/lifemonitor/api/models/repositories/github.py
+++ b/lifemonitor/api/models/repositories/github.py
@@ -210,6 +210,11 @@ class InstallationGithubWorkflowRepository(GithubRepository, WorkflowRepository)
         return owner.login if owner else None
 
     @property
+    def owner_id(self) -> int:
+        owner = super().owner
+        return owner.id if owner else None
+
+    @property
     def license(self) -> Optional[str]:
         if not self._license:
             try:

--- a/lifemonitor/api/models/repositories/github.py
+++ b/lifemonitor/api/models/repositories/github.py
@@ -206,8 +206,8 @@ class InstallationGithubWorkflowRepository(GithubRepository, WorkflowRepository)
 
     @property
     def owner(self) -> str:
-        onwer = super().owner
-        return onwer.login if onwer else None
+        owner = super().owner
+        return owner.login if owner else None
 
     @property
     def license(self) -> Optional[str]:

--- a/lifemonitor/api/models/workflows.py
+++ b/lifemonitor/api/models/workflows.py
@@ -90,6 +90,10 @@ class Workflow(Resource):
         return None
 
     @hybrid_property
+    def earliest_version(self) -> WorkflowVersion:
+        return min(self.versions.values(), key=lambda v: v.created)
+
+    @hybrid_property
     def latest_version(self) -> WorkflowVersion:
         return max(self.versions.values(), key=lambda v: v.created)
 

--- a/lifemonitor/integrations/github/controllers.py
+++ b/lifemonitor/integrations/github/controllers.py
@@ -249,7 +249,7 @@ def __notify_workflow_version_event__(repo_reference: GithubRepositoryReference,
         logger.debug("Notifications enabled: %r", notification_enabled)
         if notification_enabled:
             logger.debug(f"Setting notification for action '{action}' on repo '{repo.full_name}' (ref: {repo.ref})")
-            identity = OAuthIdentity.find_by_provider_user_id(str(repo.owner.id), "github")
+            identity = OAuthIdentity.find_by_provider_user_id(str(repo.owner_id), "github")
             if identity:
                 version = workflow_version if isinstance(workflow_version, dict) else serializers.WorkflowVersionSchema(exclude=('meta', 'links')).dump(workflow_version)
                 repo_data = repo.raw_data

--- a/lifemonitor/integrations/github/controllers.py
+++ b/lifemonitor/integrations/github/controllers.py
@@ -834,7 +834,7 @@ def handle_event():
         logger.debug(str(e))
 
     # check the author of the current pull_request
-    if event.pusher == event.application.bot:
+    if event.pusher_name == event.application.bot:
         logger.debug("Nothing to do: commit pushed by LifeMonitor[Bot]")
         return f"Push created by {event.application.bot}", 204
 

--- a/lifemonitor/integrations/github/controllers.py
+++ b/lifemonitor/integrations/github/controllers.py
@@ -41,8 +41,6 @@ from lifemonitor.api.models.repositories.github import GithubWorkflowRepository
 from lifemonitor.api.models.testsuites.testinstance import TestInstance
 from lifemonitor.api.models.wizards import QuestionStep, UpdateStep
 from lifemonitor.api.models.workflows import WorkflowVersion
-from lifemonitor.auth.models import User
-from lifemonitor.auth.oauth2.client.models import OAuthIdentity
 from lifemonitor.auth.services import authorized, current_user
 from lifemonitor.integrations.github import pull_requests
 from lifemonitor.integrations.github.app import LifeMonitorGithubApp

--- a/lifemonitor/integrations/github/controllers.py
+++ b/lifemonitor/integrations/github/controllers.py
@@ -41,7 +41,7 @@ from lifemonitor.api.models.repositories.github import GithubWorkflowRepository
 from lifemonitor.api.models.testsuites.testinstance import TestInstance
 from lifemonitor.api.models.wizards import QuestionStep, UpdateStep
 from lifemonitor.api.models.workflows import WorkflowVersion
-from lifemonitor.auth.services import authorized, current_user
+from lifemonitor.auth.services import User, authorized, current_user
 from lifemonitor.integrations.github import pull_requests
 from lifemonitor.integrations.github.app import LifeMonitorGithubApp
 from lifemonitor.integrations.github.events import (GithubEvent,

--- a/lifemonitor/integrations/github/events.py
+++ b/lifemonitor/integrations/github/events.py
@@ -95,8 +95,12 @@ class GithubEvent():
         return self._headers
 
     @property
-    def pusher(self) -> str:
+    def pusher_name(self) -> str:
         return self._raw_data['pusher']['name'] if 'pusher' in self._raw_data else None
+
+    @property
+    def sender_name(self) -> str:
+        return self._raw_data['sender']['login'] if 'sender' in self._raw_data else None
 
     @property
     def sender(self) -> OAuthIdentity:

--- a/lifemonitor/integrations/github/services.py
+++ b/lifemonitor/integrations/github/services.py
@@ -138,8 +138,7 @@ def register_repository_workflow(repository_reference: GithubRepositoryReference
         # set the workflow version name
         workflow_version = repository_reference.branch or repository_reference.tag
         # search user identity
-        identity: OAuthIdentity = hosting_service.server_credentials\
-            .find_identity_by_provider_user_id(str(repository_reference.owner_id))
+        identity: OAuthIdentity = repository_reference.event.sender
         repo_owner = identity.user
         logger.debug("Workflow Submitter: %r", repo_owner)
         # set the repo link
@@ -224,8 +223,7 @@ def delete_repository_workflow_version(repository_reference: GithubRepositoryRef
         # set the workflow version name
         workflow_version = repository_reference.branch or repository_reference.tag
         # search user identity
-        identity: OAuthIdentity = hosting_service.server_credentials\
-            .find_identity_by_provider_user_id(str(repository_reference.owner_id))
+        identity: OAuthIdentity = repository_reference.event.sender
         repo_owner = identity.user
         # set the repo link
         repo_link = f"{hosting_service.uri}/{repo.full_name}.git"

--- a/lifemonitor/integrations/github/services.py
+++ b/lifemonitor/integrations/github/services.py
@@ -217,7 +217,7 @@ def delete_repository_workflow_version(repository_reference: GithubRepositoryRef
     try:
         # set reference to the github workflow registry
         github_registry: GithubWorkflowRegistry = repository_reference.event.installation.github_registry
-        # set a reference to the Gihub hosting service instance
+        # set a reference to the Github hosting service instance
         hosting_service: HostingService = repository_reference.hosting_service
         logger.debug("Hosting service: %r", hosting_service)
         # set the workflow version name


### PR DESCRIPTION
This PR fixes the identification of the LifeMonitor user to be used for submitting workflows on LifeMonitor, starting from an update of the corresponding workflow repository on a Github organisation.