### PR TITLE
feat: enrich workflow API responses with test and build data

### DIFF
--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -172,7 +172,7 @@ def _get_workflows_list_(page: int = 1, per_page: Optional[int] = None, max_item
 @cached(timeout=Timeout.REQUEST)
 def workflows_get(status=False, versions=False, subscriptions=False,
                   suites: bool = False, instances: bool = False,
-                  builds: bool = False, build_limit: int = 1,
+                  builds: bool = False, builds_limit: int = 1,
                   page: int = 1, per_page: Optional[int] = None,
                   max_items: Optional[int] = None,
                   only_subscriptions=False,
@@ -194,9 +194,10 @@ def workflows_get(status=False, versions=False, subscriptions=False,
         include_suites=suites,
         include_instances=instances,
         include_builds=builds,
-        builds_limit=build_limit,
+        builds_limit=builds_limit,
         page=page_info
     )
+
     return serializer.dump(workflows)
 
 
@@ -238,25 +239,42 @@ def workflows_get_by_id(wf_uuid, wf_version):
 
 
 @cached(timeout=Timeout.REQUEST)
-def workflows_get_latest_version_by_id(wf_uuid, previous_versions=False, ro_crate=False):
+def workflows_get_latest_version_by_id(
+        wf_uuid, previous_versions=False, ro_crate=False,
+        status=False,
+        suites=True, instances=False,
+        builds=False, builds_limit=1):
     response = __get_workflow_version__(wf_uuid, None)
     exclude = ['previous_versions'] if not previous_versions else []
     logger.debug("Previous versions: %r", exclude)
     return response if isinstance(response, Response) \
         else serializers.LatestWorkflowVersionSchema(
             exclude=exclude, rocrate_metadata=ro_crate,
-            subscriptionsOf=[current_user] if not current_user.is_anonymous else None).dump(response)
+            subscriptionsOf=[current_user] if not current_user.is_anonymous else None,
+            status=status,
+            include_suites=suites,
+            include_instances=instances,
+            include_builds=builds,
+            builds_limit=builds_limit).dump(response)
 
 
 @cached(timeout=Timeout.REQUEST)
-def workflows_get_version_by_id(wf_uuid, wf_version, ro_crate=False):
+def workflows_get_version_by_id(wf_uuid, wf_version, ro_crate=False,
+                                status=False,
+                                suites=True, instances=False,
+                                builds=False, builds_limit=1):
     response = __get_workflow_version__(wf_uuid, wf_version)
     exclude = ['previous_versions']
     logger.debug("Previous versions: %r", exclude)
     return response if isinstance(response, Response) \
         else serializers.LatestWorkflowVersionSchema(
             exclude=exclude, rocrate_metadata=ro_crate,
-            subscriptionsOf=[current_user] if not current_user.is_anonymous else None).dump(response)
+            subscriptionsOf=[current_user] if not current_user.is_anonymous else None,
+            status=status,
+            include_suites=suites,
+            include_instances=instances,
+            include_builds=builds,
+            builds_limit=builds_limit).dump(response)
 
 
 @cached(timeout=Timeout.REQUEST)
@@ -304,7 +322,7 @@ def workflows_rocrate_download(wf_uuid, wf_version):
 @cached(timeout=Timeout.REQUEST)
 def registry_workflows_get(status=False, versions=False, stats=False,
                            suites=False, instances=False,
-                           builds=False, build_limit=1,
+                           builds=False, builds_limit=1,
                            page=None, per_page=None, max_items=None):
     page_info = PaginationInfo(page=page, per_page=per_page, max_items=max_items)
     workflows = lm.get_registry_workflows(current_registry, page=page_info)
@@ -315,7 +333,7 @@ def registry_workflows_get(status=False, versions=False, stats=False,
         include_suites=suites,
         include_instances=instances,
         include_builds=builds,
-        builds_limit=build_limit,
+        builds_limit=builds_limit,
         page=page_info
     ).dump(workflows)
 
@@ -333,7 +351,7 @@ def registry_workflows_post(body):
 def registry_user_workflows_get(user_id, status=False, versions=False,
                                 stats=False,
                                 suites=False, instances=False,
-                                builds=False, build_limit=1,
+                                builds=False, builds_limit=1,
                                 page=None, per_page=None, max_items=None):
     if not current_registry:
         return lm_exceptions.report_problem(401, "Unauthorized", detail=messages.no_registry_found)
@@ -346,7 +364,7 @@ def registry_user_workflows_get(user_id, status=False, versions=False,
             workflow_status=status, workflow_versions=versions,
             statistics=lm.get_workflows_stats(workflows) if stats else None,
             include_suites=suites, include_instances=instances,
-            include_builds=builds, builds_limit=build_limit,
+            include_builds=builds, builds_limit=builds_limit,
             page=page_info).dump(workflows)
     except OAuthIdentityNotFoundException as e:
         if logger.isEnabledFor(logging.DEBUG):
@@ -369,7 +387,7 @@ def registry_user_workflows_post(user_id, body):
 def user_workflows_get(status=False, versions=False, subscriptions=False, only_subscriptions: bool = False,
                        stats=False,
                        suites=False, instances=False,
-                       builds=False, build_limit=1,
+                       builds=False, builds_limit=1,
                        page=None, per_page=None, max_items=None):
     if not current_user or current_user.is_anonymous:
         return lm_exceptions.report_problem(401, "Unauthorized", detail=messages.no_user_in_session)
@@ -387,7 +405,7 @@ def user_workflows_get(status=False, versions=False, subscriptions=False, only_s
                                        include_suites=suites,
                                        include_instances=instances,
                                        include_builds=builds,
-                                       builds_limit=build_limit,
+                                       builds_limit=builds_limit,
                                        page=page_info).dump(workflows)
 
 

--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -171,6 +171,8 @@ def _get_workflows_list_(page: int = 1, per_page: Optional[int] = None, max_item
 
 @cached(timeout=Timeout.REQUEST)
 def workflows_get(status=False, versions=False, subscriptions=False,
+                  suites: bool = False, instances: bool = False,
+                  builds: bool = False, build_limit: int = 1,
                   page: int = 1, per_page: Optional[int] = None,
                   max_items: Optional[int] = None,
                   only_subscriptions=False,
@@ -189,6 +191,10 @@ def workflows_get(status=False, versions=False, subscriptions=False,
         workflow_versions=versions,
         subscriptionsOf=subscriptions_of,
         statistics=lm.get_workflows_stats(workflows) if stats else None,
+        include_suites=suites,
+        include_instances=instances,
+        include_builds=builds,
+        builds_limit=build_limit,
         page=page_info
     )
     return serializer.dump(workflows)
@@ -297,6 +303,8 @@ def workflows_rocrate_download(wf_uuid, wf_version):
 @authorized
 @cached(timeout=Timeout.REQUEST)
 def registry_workflows_get(status=False, versions=False, stats=False,
+                           suites=False, instances=False,
+                           builds=False, build_limit=1,
                            page=None, per_page=None, max_items=None):
     page_info = PaginationInfo(page=page, per_page=per_page, max_items=max_items)
     workflows = lm.get_registry_workflows(current_registry, page=page_info)
@@ -304,6 +312,10 @@ def registry_workflows_get(status=False, versions=False, stats=False,
     return serializers.ListOfWorkflows(
         workflow_status=status, workflow_versions=versions,
         statistics=lm.get_workflows_stats(workflows) if stats else None,
+        include_suites=suites,
+        include_instances=instances,
+        include_builds=builds,
+        builds_limit=build_limit,
         page=page_info
     ).dump(workflows)
 
@@ -320,6 +332,8 @@ def registry_workflows_post(body):
 @cached(timeout=Timeout.REQUEST)
 def registry_user_workflows_get(user_id, status=False, versions=False,
                                 stats=False,
+                                suites=False, instances=False,
+                                builds=False, build_limit=1,
                                 page=None, per_page=None, max_items=None):
     if not current_registry:
         return lm_exceptions.report_problem(401, "Unauthorized", detail=messages.no_registry_found)
@@ -330,8 +344,10 @@ def registry_user_workflows_get(user_id, status=False, versions=False,
         logger.debug("registry_user_workflows_get. Got %s workflows (user: %s)", len(workflows), current_user)
         return serializers.ListOfWorkflows(
             workflow_status=status, workflow_versions=versions,
-            statistics=lm.get_workflows_stats(workflows) if stats else None, page=page_info
-        ).dump(workflows)
+            statistics=lm.get_workflows_stats(workflows) if stats else None,
+            include_suites=suites, include_instances=instances,
+            include_builds=builds, builds_limit=build_limit,
+            page=page_info).dump(workflows)
     except OAuthIdentityNotFoundException as e:
         if logger.isEnabledFor(logging.DEBUG):
             logger.exception(e)
@@ -352,6 +368,8 @@ def registry_user_workflows_post(user_id, body):
 @cached(timeout=Timeout.REQUEST)
 def user_workflows_get(status=False, versions=False, subscriptions=False, only_subscriptions: bool = False,
                        stats=False,
+                       suites=False, instances=False,
+                       builds=False, build_limit=1,
                        page=None, per_page=None, max_items=None):
     if not current_user or current_user.is_anonymous:
         return lm_exceptions.report_problem(401, "Unauthorized", detail=messages.no_user_in_session)
@@ -366,6 +384,10 @@ def user_workflows_get(status=False, versions=False, subscriptions=False, only_s
                                        workflow_versions=versions,
                                        subscriptionsOf=[current_user] if subscriptions else None,
                                        statistics=lm.get_workflows_stats(workflows) if stats else None,
+                                       include_suites=suites,
+                                       include_instances=instances,
+                                       include_builds=builds,
+                                       builds_limit=build_limit,
                                        page=page_info).dump(workflows)
 
 
@@ -433,6 +455,8 @@ def user_workflow_unsubscribe(wf_uuid):
 @authorized
 @cached(timeout=Timeout.REQUEST)
 def user_registry_workflows_get(registry_uuid, status=False, versions=False,
+                                suites=False, instances=False,
+                                builds=False, build_limit=1,
                                 page: int = 0, per_page: Optional[int] = None,
                                 max_items: Optional[int] = None):
     if not current_user or current_user.is_anonymous:
@@ -444,7 +468,9 @@ def user_registry_workflows_get(registry_uuid, status=False, versions=False,
         workflows = lm.get_user_registry_workflows(current_user, registry, page=page_info)
         logger.debug("workflows_get. Got %s workflows (user: %s)", len(workflows), current_user)
         return serializers.ListOfWorkflows(
-            workflow_status=status, workflow_versions=versions, page=page_info).dump(workflows)
+            workflow_status=status, workflow_versions=versions, include_suites=suites, include_instances=instances,
+            include_builds=builds, builds_limit=build_limit,
+            page=page_info).dump(workflows)
     except lm_exceptions.EntityNotFoundException:
         return lm_exceptions.report_problem(404, "Not Found",
                                             detail=messages.no_registry_found.format(registry_uuid))
@@ -791,11 +817,9 @@ def _get_suite_or_problem(suite_uuid):
                                                     extra_info={"reason": response.get_json()['detail']})
             details_message = ""
             if current_user and not current_user.is_anonymous:
-                details_message = messages.unauthorized_user_suite_access\
-                    .format(current_user.username, suite_uuid)
+                details_message = messages.unauthorized_user_suite_access.format(current_user.username, suite_uuid)
             elif current_registry:
-                details_message = messages.unauthorized_registry_suite_access\
-                    .format(current_registry.name, suite_uuid)
+                details_message = messages.unauthorized_registry_suite_access.format(current_registry.name, suite_uuid)
             return lm_exceptions.report_problem(403, "Forbidden",
                                                 detail=details_message,
                                                 extra_info={"reason": response.get_json()['detail']})
@@ -808,7 +832,7 @@ def _get_suite_or_problem(suite_uuid):
 def suites_get_by_uuid(suite_uuid, status: bool = False, latest_builds: bool = False):
     suite = _get_suite_or_problem(suite_uuid)
     try:
-        return suite if isinstance(suite, Response) \
+        return suite if isinstance(suite, Response)\
             else serializers.SuiteSchema(status=status, latest_builds=latest_builds).dump(suite)
     except Exception as e:
         return __handle_testing_service_error__(e, instance_uuid=suite_uuid,
@@ -824,7 +848,7 @@ def suites_get_by_uuid(suite_uuid, status: bool = False, latest_builds: bool = F
 def suites_get_status(suite_uuid):
     suite = _get_suite_or_problem(suite_uuid)
     try:
-        return suite if isinstance(suite, Response) \
+        return suite if isinstance(suite, Response)\
             else serializers.SuiteStatusSchema().dump(suite)
     except Exception as e:
         return __handle_testing_service_error__(e, instance_uuid=suite_uuid,
@@ -853,7 +877,7 @@ def __handle_testing_service_error__(e: Exception, instance_uuid: str = None, me
 @cached(timeout=Timeout.REQUEST)
 def suites_get_instances(suite_uuid):
     response = _get_suite_or_problem(suite_uuid)
-    return response if isinstance(response, Response) \
+    return response if isinstance(response, Response)\
         else serializers.ListOfTestInstancesSchema().dump(response.test_instances)
 
 
@@ -947,11 +971,9 @@ def _get_instances_or_problem(instance_uuid):
                                                     extra_info={"reason": response.get_json()['detail']})
             details_message = ""
             if current_user and not current_user.is_anonymous:
-                details_message = messages.unauthorized_user_instance_access\
-                    .format(current_user.username, instance_uuid)
+                details_message = messages.unauthorized_user_instance_access.format(current_user.username, instance_uuid)
             elif current_registry:
-                details_message = messages.unauthorized_registry_instance_access\
-                    .format(current_registry.name, instance_uuid)
+                details_message = messages.unauthorized_registry_instance_access.format(current_registry.name, instance_uuid)
             return lm_exceptions.report_problem(403, "Forbidden", detail=details_message,
                                                 extra_info={"reason": response.get_json()})
         return instance
@@ -1042,13 +1064,11 @@ def instances_builds_get_by_id(instance_uuid, build_id):
         if build:
             return serializers.BuildSummarySchema().dump(build)
         else:
-            return lm_exceptions\
-                .report_problem(404, "Not Found",
-                                detail=messages.instance_build_not_found.format(build_id, instance_uuid))
+            return lm_exceptions.report_problem(404, "Not Found",
+                                                detail=messages.instance_build_not_found.format(build_id, instance_uuid))
     except lm_exceptions.EntityNotFoundException:
-        return lm_exceptions\
-            .report_problem(404, "Not Found",
-                            detail=messages.instance_build_not_found.format(build_id, instance_uuid))
+        return lm_exceptions.report_problem(404, "Not Found",
+                                            detail=messages.instance_build_not_found.format(build_id, instance_uuid))
     except lm_exceptions.RateLimitExceededException as e:
         return lm_exceptions.report_problem(403, e.title, detail=e.detail)
     except lm_exceptions.BadRequestException as e:
@@ -1071,13 +1091,11 @@ def instances_builds_get_logs(instance_uuid, build_id, offset_bytes=0, limit_byt
         logger.debug("offset = %r, limit = %r", offset_bytes, limit_bytes)
         if build:
             return build.get_output(offset_bytes=offset_bytes, limit_bytes=limit_bytes)
-        return lm_exceptions\
-            .report_problem(404, "Not Found",
-                            detail=messages.instance_build_not_found.format(build_id, instance_uuid))
+        return lm_exceptions.report_problem(404, "Not Found",
+                                            detail=messages.instance_build_not_found.format(build_id, instance_uuid))
     except lm_exceptions.EntityNotFoundException:
-        return lm_exceptions\
-            .report_problem(404, "Not Found",
-                            detail=messages.instance_build_not_found.format(build_id, instance_uuid))
+        return lm_exceptions.report_problem(404, "Not Found",
+                                            detail=messages.instance_build_not_found.format(build_id, instance_uuid))
     except lm_exceptions.RateLimitExceededException as e:
         return lm_exceptions.report_problem(403, e.title, detail=e.detail)
     except ValueError as e:

--- a/lifemonitor/api/models/testsuites/testsuite.py
+++ b/lifemonitor/api/models/testsuites/testsuite.py
@@ -123,11 +123,27 @@ class TestSuite(db.Model, ModelMixin):
     @property
     def latest_test_builds(self) -> list[models.TestBuild]:
         """
-        Get the latest test builds across all test instances in this suite.
+        Get the latest test builds across all test instances in this suite,
+        one per test instance.
         """
         latest_builds = []
         for test_instance in self.test_instances:
             latest_builds.append(test_instance.last_test_build)
+        return latest_builds
+
+    def get_latest_builds(self, limit=None) -> list[models.TestBuild]:
+        """
+        Retrieve the most recent test builds from all test instances in this suite,
+        up to the specified limit.
+        """
+        latest_builds = []
+        for test_instance in self.test_instances:
+            builds = test_instance.get_test_builds(limit=limit)
+            latest_builds.extend(builds)
+        # sort by updated at descending
+        latest_builds.sort(key=lambda x: x.updated_at, reverse=True)
+        if limit:
+            return latest_builds[:limit]
         return latest_builds
 
     @classmethod

--- a/lifemonitor/api/serializers.py
+++ b/lifemonitor/api/serializers.py
@@ -179,6 +179,30 @@ class VersionDetailsBaseSchema(BaseSchema):
         ).dump(suites)['items']
 
 
+def get_rocrate(obj: models.WorkflowVersion, exclude_metadata: bool = False):
+    rocrate = {
+        'links': {
+            'origin': "local file uploaded" if obj.uri.startswith("tmp://") else obj.uri,
+            'metadata': urljoin(lm_utils.get_external_server_url(),
+                                f"workflows/{obj.workflow.uuid}/rocrate/{obj.version}/metadata"),
+            'download': urljoin(lm_utils.get_external_server_url(),
+                                f"workflows/{obj.workflow.uuid}/rocrate/{obj.version}/download")
+        }
+    }
+    try:
+        if obj.based_on:
+            rocrate['links']['based_on'] = obj.based_on
+        rocrate['links']['registries'] = {}
+        for r_name, rv in obj.registry_workflow_versions.items():
+            rocrate['links']['registries'][r_name] = rv.link
+        if not exclude_metadata:
+            rocrate['metadata'] = obj.crate_metadata
+    except Exception as e:
+        rocrate['unavailable'] = True
+        rocrate['unavailability_reason'] = str(e)
+    return rocrate
+
+
 class VersionDetailsSchema(BaseSchema):
     __envelope__ = {"single": None, "many": "items"}
 
@@ -201,7 +225,7 @@ class VersionDetailsSchema(BaseSchema):
     def __init__(self, *args,
                  include_suites=False, include_instances=False,
                  include_builds=False, builds_limit=1,
-                 include_status=False,
+                 include_status=False, rocrate_metadata=False,
                  **kwargs):
         exclude = kwargs.pop('exclude', ('status',) if "status" not in kwargs.get('only', ()) else ())
         super().__init__(*args, exclude=exclude, **kwargs)
@@ -210,6 +234,7 @@ class VersionDetailsSchema(BaseSchema):
         self.include_builds = include_builds
         self.builds_limit = builds_limit
         self.include_status = include_status
+        self.rocrate_metadata = rocrate_metadata
 
     def get_links(self, obj: models.WorkflowVersion):
         links = {
@@ -230,29 +255,9 @@ class VersionDetailsSchema(BaseSchema):
             return None
 
     def get_rocrate(self, obj: models.WorkflowVersion):
-        rocrate = {
-            'links': {
-                'origin': "local file uploaded" if obj.uri.startswith("tmp://") else obj.uri,
-                'metadata': urljoin(lm_utils.get_external_server_url(),
-                                    f"workflows/{obj.workflow.uuid}/rocrate/{obj.version}/metadata"),
-                'download': urljoin(lm_utils.get_external_server_url(),
-                                    f"workflows/{obj.workflow.uuid}/rocrate/{obj.version}/download")
-            }
-        }
-        try:
-            if obj.based_on:
-                rocrate['links']['based_on'] = obj.based_on
-            rocrate['links']['registries'] = {}
-            for r_name, rv in obj.registry_workflow_versions.items():
-                rocrate['links']['registries'][r_name] = rv.link
-            rocrate['metadata'] = obj.crate_metadata
-            if 'rocrate_metadata' in self.exclude or \
-                    self.only and 'rocrate_metadata' not in self.only:
-                del rocrate['metadata']
-        except Exception as e:
-            rocrate['unavailable'] = True
-            rocrate['unavailability_reason'] = str(e)
-        return rocrate
+        exclude_metadata = 'rocrate_metadata' in self.exclude or \
+            self.only and 'rocrate_metadata' not in self.only or not self.rocrate_metadata
+        return get_rocrate(obj, exclude_metadata=exclude_metadata)
 
     def get_suites(self, obj: models.WorkflowVersion):
         if not self.include_suites:
@@ -295,6 +300,8 @@ class WorkflowVersionSchema(ResourceSchema):
     subscriptions = fields.Method("get_subscriptions")
 
     status = fields.Method('get_status')
+
+    ro_crate = fields.Method("get_rocrate")
 
     rocrate_metadata = False
     subscriptionsOf: List[auth_models.User] = None
@@ -342,6 +349,11 @@ class WorkflowVersionSchema(ResourceSchema):
                 if s:
                     result.append(SubscriptionSchema(exclude=('meta', 'links'), self_link=False).dump(s))
         return result
+
+    def get_rocrate(self, obj: models.WorkflowVersion):
+        exclude_metadata = 'rocrate_metadata' in self.exclude or \
+            self.only and 'rocrate_metadata' not in self.only or not self.rocrate_metadata
+        return get_rocrate(obj, exclude_metadata=exclude_metadata)
 
     def get_suites(self, obj: models.WorkflowVersion):
         if not self.include_suites:
@@ -393,7 +405,7 @@ class LatestWorkflowVersionSchema(WorkflowVersionSchema):
         self.rocrate_metadata = rocrate_metadata
 
     def get_versions(self, obj: models.WorkflowVersion):
-        only = ["uuid", "version", "ro_crate"]
+        only = ["uuid", "version"]
         if self.rocrate_metadata:
             only.append("ro_crate")
         schema = VersionDetailsSchema(only=only)

--- a/lifemonitor/api/serializers.py
+++ b/lifemonitor/api/serializers.py
@@ -481,7 +481,7 @@ class WorkflowVersionListItem(WorkflowSchema):
     def get_versions(self, workflow):
         try:
             if self.workflow_versions:
-                properties = ["uuid", "version", "ro_crate", "is_latest"]
+                properties = ["uuid", "version", "authors", "ro_crate", "is_latest"]
                 if "status" not in self.exclude:
                     properties.append("status")
                 schema = VersionDetailsSchema(only=properties)

--- a/lifemonitor/api/serializers.py
+++ b/lifemonitor/api/serializers.py
@@ -446,12 +446,22 @@ class WorkflowVersionListItem(WorkflowSchema):
     status = fields.Method("get_status")
     subscriptions = fields.Method("get_subscriptions")
     versions = fields.Method("get_versions")
+    suites = fields.Method("get_suites")
 
     def __init__(self, *args, self_link: bool = True,
-                 workflow_versions: bool = False, subscriptionsOf: List[auth_models.User] = None, **kwargs):
+                 workflow_versions: bool = False, subscriptionsOf: List[auth_models.User] = None,
+                 include_suites: bool = False,
+                 include_instances: bool = False,
+                 include_builds: bool = False,
+                 builds_limit: int = 10,
+                 **kwargs):
         super().__init__(*args, self_link=self_link, **kwargs)
         self.subscriptionsOf = subscriptionsOf
         self.workflow_versions = workflow_versions
+        self.include_suites = include_suites
+        self.include_instances = include_instances
+        self.include_builds = include_builds
+        self.builds_limit = builds_limit
 
     def get_status(self, workflow):
         try:
@@ -513,6 +523,23 @@ class WorkflowVersionListItem(WorkflowSchema):
                     result.append(SubscriptionSchema(exclude=('meta', 'links'), self_link=False).dump(s))
         return result
 
+    def get_suites(self, workflow: models.Workflow):
+        if not self.include_suites:
+            return None
+        from .serializers import ListOfSuites
+        suites = []
+        for suite in workflow.latest_version.test_suites:
+            if self.include_instances:
+                for instance in suite.test_instances:
+                    if self.include_builds:
+                        instance.test_builds = instance.get_test_builds(limit=self.builds_limit)
+            suites.append(suite)
+        return ListOfSuites(
+            self_link=False,
+            status=self.include_builds,
+            latest_builds=self.include_builds
+        ).dump(suites)['items']
+
     @post_dump
     def remove_skip_values(self, data, **kwargs):
         return {
@@ -532,11 +559,17 @@ class ListOfWorkflows(ListOfItems):
                  workflow_status: bool = False, workflow_versions: bool = False,
                  subscriptionsOf: List[auth_models.User] = None,
                  statistics: Optional[object] = None,
+                 include_suites: bool = False, include_instances: bool = False,
+                 include_builds: bool = False, builds_limit: int = 1,
                  **kwargs):
         super().__init__(*args, **kwargs)
         self.workflow_status = workflow_status
         self.workflow_versions = workflow_versions
         self.subscriptionsOf = subscriptionsOf
+        self.include_suites = include_suites
+        self.include_instances = include_instances
+        self.include_builds = include_builds
+        self.builds_limit = builds_limit
         self._statistics = statistics
 
     def get_statistics(self, workflow: models.Workflow):
@@ -550,7 +583,12 @@ class ListOfWorkflows(ListOfItems):
             exclude.append('subscriptions')
         return [self.__item_scheme__(exclude=tuple(exclude), many=False,
                                      subscriptionsOf=self.subscriptionsOf,
-                                     workflow_versions=self.workflow_versions).dump(_) for _ in obj] \
+                                     workflow_versions=self.workflow_versions,
+                                     include_suites=self.include_suites,
+                                     include_instances=self.include_instances,
+                                     include_builds=self.include_builds,
+                                     builds_limit=self.builds_limit
+                                     ).dump(_) for _ in obj] \
             if self.__item_scheme__ else None
 
 
@@ -571,10 +609,12 @@ class SuiteSchema(ResourceMetadataSchema):
     latest_builds = fields.Method("get_latest_builds")
 
     def __init__(self, *args, self_link: bool = True,
-                 status: bool = False, latest_builds: bool = False, **kwargs):
+                 status: bool = False,
+                 latest_builds: bool = False, builds_limit: int = 10, **kwargs):
         super().__init__(*args, self_link=self_link, **kwargs)
         self.status = status
         self.latest_builds = latest_builds
+        self.builds_limit = builds_limit
 
     def get_definition(self, obj):
         if not hasattr(obj, 'definition') or not obj.definition:
@@ -605,9 +645,14 @@ class SuiteSchema(ResourceMetadataSchema):
                 logger.exception(e)
             return None
 
-    def get_latest_builds(self, obj):
+    def get_latest_builds(self, obj: models.TestSuite):
         try:
-            return SuiteStatusSchema(only=('latest_builds',)).dump(obj)['latest_builds'] if self.latest_builds else None
+            # return SuiteStatusSchema(only=('latest_builds',)).dump(obj)['latest_builds'] if self.latest_builds else None
+            # return ListOfTestBuildsSchema().dump(obj.get_latest_builds(limit=self.builds_limit))
+            builds = []
+            for build in obj.get_latest_builds(limit=self.builds_limit):
+                builds.append(BuildSummarySchema(exclude=('meta', 'links')).dump(build))
+            return builds
         except Exception:
             logger.warning("Unable to extract latest_builds for suite: %r", obj)
             return None

--- a/lifemonitor/api/serializers.py
+++ b/lifemonitor/api/serializers.py
@@ -140,6 +140,45 @@ class RegistryWorkflowSchema(WorkflowSchema):
     registry = fields.Nested(WorkflowRegistrySchema(exclude=('meta', 'links')), attribute="")
 
 
+class VersionDetailsBaseSchema(BaseSchema):
+
+    uuid = fields.String(attribute="uuid")
+    name = fields.String(attribute="name")
+    version = fields.String(attribute="version")
+
+    suites = fields.Method("get_suites")
+
+    def __init__(self, *args,
+                 include_suites=False, include_instances=False,
+                 include_builds=False, builds_limit=1,
+                 include_status=False,
+                 **kwargs):
+
+        super().__init__(*args, **kwargs)
+        self.include_suites = include_suites
+        self.include_instances = include_instances
+        self.include_builds = include_builds
+        self.builds_limit = builds_limit
+        self.include_status = include_status
+
+    def get_suites(self, obj: models.WorkflowVersion):
+        if not self.include_suites:
+            return None
+        from .serializers import ListOfSuites
+        suites = []
+        for suite in obj.test_suites:
+            if self.include_instances:
+                for instance in suite.test_instances:
+                    if self.include_builds:
+                        instance.test_builds = instance.get_test_builds(limit=self.builds_limit)
+            suites.append(suite)
+        return ListOfSuites(
+            self_link=False,
+            status=self.include_status,
+            latest_builds=self.include_builds
+        ).dump(suites)['items']
+
+
 class VersionDetailsSchema(BaseSchema):
     __envelope__ = {"single": None, "many": "items"}
 
@@ -153,13 +192,24 @@ class VersionDetailsSchema(BaseSchema):
     links = fields.Method('get_links')
     status = fields.Method('get_status')
 
+    suites = fields.Method("get_suites")
+
     class Meta:
         model = models.WorkflowVersion
         additional = ('rocrate_metadata',)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args,
+                 include_suites=False, include_instances=False,
+                 include_builds=False, builds_limit=1,
+                 include_status=False,
+                 **kwargs):
         exclude = kwargs.pop('exclude', ('status',) if "status" not in kwargs.get('only', ()) else ())
         super().__init__(*args, exclude=exclude, **kwargs)
+        self.include_suites = include_suites
+        self.include_instances = include_instances
+        self.include_builds = include_builds
+        self.builds_limit = builds_limit
+        self.include_status = include_status
 
     def get_links(self, obj: models.WorkflowVersion):
         links = {
@@ -204,6 +254,23 @@ class VersionDetailsSchema(BaseSchema):
             rocrate['unavailability_reason'] = str(e)
         return rocrate
 
+    def get_suites(self, obj: models.WorkflowVersion):
+        if not self.include_suites:
+            return None
+        from .serializers import ListOfSuites
+        suites = []
+        for suite in obj.test_suites:
+            if self.include_instances:
+                for instance in suite.test_instances:
+                    if self.include_builds:
+                        instance.test_builds = instance.get_test_builds(limit=self.builds_limit)
+            suites.append(suite)
+        return ListOfSuites(
+            self_link=False,
+            status=self.include_status,
+            latest_builds=self.include_builds
+        ).dump(suites)['items']
+
     @post_dump
     def remove_skip_values(self, data, **kwargs):
         return {
@@ -227,17 +294,37 @@ class WorkflowVersionSchema(ResourceSchema):
     registries = fields.Method("get_registries")
     subscriptions = fields.Method("get_subscriptions")
 
+    status = fields.Method('get_status')
+
     rocrate_metadata = False
     subscriptionsOf: List[auth_models.User] = None
 
-    def __init__(self, *args, rocrate_metadata=False, subscriptionsOf=None, **kwargs):
+    suites = fields.Method("get_suites")
+
+    def __init__(self, *args,
+                 rocrate_metadata=False,
+                 subscriptionsOf=None,
+                 status=False,
+                 include_suites=False, include_instances=False,
+                 include_builds=False, builds_limit=1,
+                 **kwargs):
         super().__init__(*args, **kwargs)
         self.rocrate_metadata = rocrate_metadata
         self.subscriptionsOf = subscriptionsOf
+        self.status = status
+        self.include_suites = include_suites
+        self.include_instances = include_instances
+        self.include_builds = include_builds
+        self.builds_limit = builds_limit
 
     def get_version(self, obj):
         try:
-            exclude = ('rocrate_metadata',) if not self.rocrate_metadata else ()
+            exclude = []
+            if not self.rocrate_metadata:
+                exclude.append('ro_crate')
+            if not self.status:
+                exclude.append('status')
+            # exclude = ('ro_crate',) if not self.rocrate_metadata else ()
         except Exception as e:
             exclude = ('rocrate_metadata',)
             if logger.isEnabledFor(logging.DEBUG):
@@ -256,11 +343,34 @@ class WorkflowVersionSchema(ResourceSchema):
                     result.append(SubscriptionSchema(exclude=('meta', 'links'), self_link=False).dump(s))
         return result
 
+    def get_suites(self, obj: models.WorkflowVersion):
+        if not self.include_suites:
+            return None
+        from .serializers import ListOfSuites
+        return ListOfSuites(
+            self_link=False,
+            status=self.include_builds,
+            include_builds=self.include_builds,
+            include_instances=self.include_instances,
+            latest_builds=self.include_builds,
+            builds_limit=self.builds_limit
+        ).dump(obj.test_suites)['items']
+
     def get_registries(self, obj):
         result = []
         for r in obj.registries:
             result.append(WorkflowRegistrySchema(exclude=('meta', 'links'), self_link=False).dump(r))
         return result
+
+    def get_status(self, obj: models.WorkflowVersion):
+        try:
+            logger.error("Getting status for workflow version %s %r", obj, self.status)
+            if self.status:
+                return WorkflowStatusSchema(only=('aggregate_test_status', 'latest_builds', 'reason')).dump(obj)
+            return None
+        except Exception as e:
+            logger.exception(e)
+            return None
 
     @post_dump
     def remove_skip_values(self, data, **kwargs):
@@ -274,8 +384,19 @@ class LatestWorkflowVersionSchema(WorkflowVersionSchema):
 
     previous_versions = fields.Method("get_versions")
 
+    def __init__(self, *args,
+                 rocrate_metadata=False,
+                 **kwargs):
+        super().__init__(*args,
+                         rocrate_metadata=rocrate_metadata,
+                         **kwargs)
+        self.rocrate_metadata = rocrate_metadata
+
     def get_versions(self, obj: models.WorkflowVersion):
-        schema = VersionDetailsSchema(only=("uuid", "version", "ro_crate"))
+        only = ["uuid", "version", "ro_crate"]
+        if self.rocrate_metadata:
+            only.append("ro_crate")
+        schema = VersionDetailsSchema(only=only)
         return [schema.dump(v)
                 for v in obj.workflow.versions.values() if not v.is_latest]
 
@@ -288,6 +409,17 @@ class ListOfWorkflowVersions(ResourceMetadataSchema):
 
     workflow = fields.Method("get_workflow")
     versions = fields.Method("get_versions")
+
+    def __init__(self, *args,
+                 self_link=True,
+                 rocrate_metadata=False,
+                 subscriptionsOf=None,
+                 include_suites=False,
+                 include_instances=False,
+                 include_builds=False,
+                 builds_limit=None,
+                 **kwargs):
+        super().__init__(*args, self_link=self_link, **kwargs)
 
     def get_workflow(self, obj: models.Workflow):
         return WorkflowSchema(exclude=('meta',)).dump(obj)
@@ -322,6 +454,15 @@ class TestInstanceSchema(ResourceMetadataSchema):
     service = fields.Method("get_testing_service")
     links = fields.Method('get_links')
 
+    builds = fields.Method("get_builds")
+
+    def __init__(self, *args,
+                 self_link=True,
+                 builds_limit=10,
+                 **kwargs):
+        super().__init__(*args, self_link=self_link, **kwargs)
+        self.builds_limit = builds_limit
+
     def get_links(self, obj):
         links = {}
         try:
@@ -340,6 +481,19 @@ class TestInstanceSchema(ResourceMetadataSchema):
             'url': obj.testing_service.url,
             'type': obj.testing_service._type.replace('_testing_service', '')
         }
+
+    def get_builds(self, obj: models.TestInstance):
+        try:
+            builds = []
+            for build in obj.get_test_builds(limit=self.builds_limit):
+                builds.append(BuildSummarySchema(
+                    exclude=('meta', 'links',
+                             'suite_uuid', 'instance_uuid',
+                             'instance')).dump(build))
+            return builds
+        except Exception:
+            logger.warning("Unable to extract latest_builds for suite: %r", obj)
+            return None
 
     @post_dump
     def remove_skip_values(self, data, **kwargs):
@@ -364,17 +518,21 @@ class BuildSummarySchema(ResourceMetadataSchema):
     class Meta:
         model = models.TestBuild
 
-    def __init__(self, *args, self_link: bool = True, exclude_nested=True, **kwargs):
+    def __init__(self, *args, self_link: bool = True,
+                 exclude_nested=True,
+                 exclude_instance_builds=False,
+                 **kwargs):
         exclude = set(kwargs.pop('exclude', ()))
         if exclude_nested:
             exclude = exclude.union(('suite', 'workflow'))
         super().__init__(*args, self_link=self_link, exclude=tuple(exclude), **kwargs)
+        self.exclude_instance_builds = exclude_instance_builds
 
     build_id = fields.String(attribute="id")
     suite_uuid = fields.String(attribute="test_instance.test_suite.uuid")
+    instance_uuid = fields.String(attribute="test_instance.uuid")
     status = fields.String()
-    instance = ma.Nested(TestInstanceSchema(self_link=False, exclude=('meta',)),
-                         attribute="test_instance")
+    instance = fields.Method("get_instance")
     timestamp = fields.String()
     duration = fields.Integer()
     links = fields.Method('get_links')
@@ -390,6 +548,10 @@ class BuildSummarySchema(ResourceMetadataSchema):
         if self._self_link:
             links['self'] = self.self_link
         return links
+
+    def get_instance(self, obj):
+        exclude = ('meta',) if self.exclude_instance_builds else ('meta', 'builds')
+        return TestInstanceSchema(self_link=False, exclude=exclude).dump(obj.test_instance)
 
 
 class WorkflowStatusSchema(WorkflowVersionSchema):
@@ -415,7 +577,7 @@ class WorkflowStatusSchema(WorkflowVersionSchema):
 
     def get_latest_builds(self, workflow_version):
         try:
-            return BuildSummarySchema(exclude=('meta', 'links'), many=True).dump(
+            return BuildSummarySchema(exclude=('meta', 'links', 'instance_uuid'), many=True).dump(
                 workflow_version.status.latest_builds)
         except Exception as e:
             logger.debug(e)
@@ -508,7 +670,7 @@ class WorkflowVersionListItem(WorkflowSchema):
             latest_builds = workflow.latest_version.status.latest_builds
             builds = []
             if latest_builds and len(latest_builds) > 0:
-                builds.append(BuildSummarySchema(exclude=('meta', 'links')).dump(latest_builds[0]))
+                builds.append(BuildSummarySchema(exclude=('meta', 'links', 'instance_uuid')).dump(latest_builds[0]))
             return builds
         except Exception as e:
             logger.debug(e)
@@ -527,18 +689,15 @@ class WorkflowVersionListItem(WorkflowSchema):
         if not self.include_suites:
             return None
         from .serializers import ListOfSuites
-        suites = []
-        for suite in workflow.latest_version.test_suites:
-            if self.include_instances:
-                for instance in suite.test_instances:
-                    if self.include_builds:
-                        instance.test_builds = instance.get_test_builds(limit=self.builds_limit)
-            suites.append(suite)
         return ListOfSuites(
             self_link=False,
             status=self.include_builds,
-            latest_builds=self.include_builds
-        ).dump(suites)['items']
+            latest_builds=self.include_builds,
+            include_builds=self.include_builds,
+            builds_limit=self.builds_limit,
+            include_instances=self.include_instances,
+            exclude=('meta', 'links')
+        ).dump(workflow.latest_version.test_suites)['items']
 
     @post_dump
     def remove_skip_values(self, data, **kwargs):
@@ -603,17 +762,21 @@ class SuiteSchema(ResourceMetadataSchema):
     roc_suite = fields.String(attribute="roc_suite")
     name = ma.auto_field()
     definition = fields.Method("get_definition")
-    instances = fields.Nested(TestInstanceSchema(self_link=False, exclude=('meta',)),
-                              attribute="test_instances", many=True)
     aggregate_test_status = fields.Method("get_status")
     latest_builds = fields.Method("get_latest_builds")
+    instances = fields.Method("get_instances")
 
     def __init__(self, *args, self_link: bool = True,
                  status: bool = False,
-                 latest_builds: bool = False, builds_limit: int = 10, **kwargs):
+                 latest_builds: bool = False,
+                 include_builds: bool = False,
+                 include_instances: bool = True,
+                 builds_limit: int = 10, **kwargs):
         super().__init__(*args, self_link=self_link, **kwargs)
         self.status = status
         self.latest_builds = latest_builds
+        self.include_builds = include_builds
+        self.include_instances = include_instances
         self.builds_limit = builds_limit
 
     def get_definition(self, obj):
@@ -651,11 +814,20 @@ class SuiteSchema(ResourceMetadataSchema):
             # return ListOfTestBuildsSchema().dump(obj.get_latest_builds(limit=self.builds_limit))
             builds = []
             for build in obj.get_latest_builds(limit=self.builds_limit):
-                builds.append(BuildSummarySchema(exclude=('meta', 'links')).dump(build))
+                builds.append(BuildSummarySchema(exclude=('meta', 'links', 'builds')).dump(build))
             return builds
         except Exception:
             logger.warning("Unable to extract latest_builds for suite: %r", obj)
             return None
+
+    def get_instances(self, obj):
+        if not self.include_instances:
+            return None
+        return TestInstanceSchema(
+            self_link=False,
+            builds_limit=self.builds_limit,
+            exclude=('meta', 'links') if self.include_builds else ('meta', 'links', 'builds')
+        ).dump(obj.test_instances, many=True)
 
     @post_dump
     def remove_skip_values(self, data, **kwargs):
@@ -671,10 +843,16 @@ class ListOfSuites(ListOfItems):
     def __init__(self, *args,
                  self_link: bool = True,
                  status: bool = False, latest_builds: bool = False,
+                 include_instances: bool = True,
+                 include_builds: bool = False,
+                 builds_limit: int = 10,
                  **kwargs):
         super().__init__(*args, self_link=self_link, **kwargs)
         self.status = status
         self.latest_builds = latest_builds
+        self.instances = include_instances
+        self.builds = include_builds
+        self.builds_limit = builds_limit
 
     def get_items(self, obj):
         exclude = ['meta', 'links']
@@ -682,10 +860,15 @@ class ListOfSuites(ListOfItems):
             exclude.append('aggregate_test_status')
         if not self.latest_builds:
             exclude.append('latest_builds')
+        if not self.instances:
+            exclude.append('instances')
         return [self.__item_scheme__(
             exclude=tuple(exclude), many=False,
             status=self.status,
-            latest_builds=self.latest_builds
+            latest_builds=self.latest_builds,
+            include_instances=self.instances,
+            include_builds=self.builds,
+            builds_limit=self.builds_limit
         ).dump(_) for _ in obj] if self.__item_scheme__ else None
 
 

--- a/lifemonitor/api/serializers.py
+++ b/lifemonitor/api/serializers.py
@@ -810,14 +810,14 @@ class SuiteSchema(ResourceMetadataSchema):
 
     def get_latest_builds(self, obj: models.TestSuite):
         try:
-            # return SuiteStatusSchema(only=('latest_builds',)).dump(obj)['latest_builds'] if self.latest_builds else None
-            # return ListOfTestBuildsSchema().dump(obj.get_latest_builds(limit=self.builds_limit))
             builds = []
             for build in obj.get_latest_builds(limit=self.builds_limit):
-                builds.append(BuildSummarySchema(exclude=('meta', 'links', 'builds')).dump(build))
+                builds.append(BuildSummarySchema(exclude=('meta', 'links')).dump(build))
             return builds
-        except Exception:
+        except Exception as e:
             logger.warning("Unable to extract latest_builds for suite: %r", obj)
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.exception(e)
             return None
 
     def get_instances(self, obj):

--- a/lifemonitor/api/serializers.py
+++ b/lifemonitor/api/serializers.py
@@ -826,7 +826,7 @@ class SuiteSchema(ResourceMetadataSchema):
         return TestInstanceSchema(
             self_link=False,
             builds_limit=self.builds_limit,
-            exclude=('meta', 'links') if self.include_builds else ('meta', 'links', 'builds')
+            exclude=('meta',) if self.include_builds else ('meta', 'builds')
         ).dump(obj.test_instances, many=True)
 
     @post_dump

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -447,6 +447,10 @@ paths:
         - $ref: "#/components/parameters/wf_versions"
         - $ref: "#/components/parameters/wf_status"
         - $ref: "#/components/parameters/statistics"
+        - $ref: "#/components/parameters/suites"
+        - $ref: "#/components/parameters/instances"
+        - $ref: "#/components/parameters/builds"
+        - $ref: "#/components/parameters/builds_limit"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
         - $ref: "#/components/parameters/max_items"
@@ -512,6 +516,10 @@ paths:
         - $ref: "#/components/parameters/registry_uuid"
         - $ref: "#/components/parameters/wf_versions"
         - $ref: "#/components/parameters/wf_status"
+        - $ref: "#/components/parameters/suites"
+        - $ref: "#/components/parameters/instances"
+        - $ref: "#/components/parameters/builds"
+        - $ref: "#/components/parameters/builds_limit"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
         - $ref: "#/components/parameters/max_items"
@@ -576,6 +584,10 @@ paths:
         - $ref: "#/components/parameters/wf_versions"
         - $ref: "#/components/parameters/wf_status"
         - $ref: "#/components/parameters/statistics"
+        - $ref: "#/components/parameters/suites"
+        - $ref: "#/components/parameters/instances"
+        - $ref: "#/components/parameters/builds"
+        - $ref: "#/components/parameters/builds_limit"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
         - $ref: "#/components/parameters/max_items"
@@ -643,6 +655,10 @@ paths:
         - $ref: "#/components/parameters/wf_versions"
         - $ref: "#/components/parameters/wf_subscriptions"
         - $ref: "#/components/parameters/statistics"
+        - $ref: "#/components/parameters/suites"
+        - $ref: "#/components/parameters/instances"
+        - $ref: "#/components/parameters/builds"
+        - $ref: "#/components/parameters/builds_limit"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
         - $ref: "#/components/parameters/max_items"
@@ -732,6 +748,10 @@ paths:
         - $ref: "#/components/parameters/wf_versions"
         - $ref: "#/components/parameters/wf_subscriptions"
         - $ref: "#/components/parameters/statistics"
+        - $ref: "#/components/parameters/suites"
+        - $ref: "#/components/parameters/instances"
+        - $ref: "#/components/parameters/builds"
+        - $ref: "#/components/parameters/builds_limit"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
         - $ref: "#/components/parameters/max_items"
@@ -818,6 +838,11 @@ paths:
         - $ref: "#/components/parameters/wf_uuid"
         - $ref: "#/components/parameters/previous_versions"
         - $ref: "#/components/parameters/rocrate_specs"
+        - $ref: "#/components/parameters/wf_status"
+        - $ref: "#/components/parameters/suites"
+        - $ref: "#/components/parameters/instances"
+        - $ref: "#/components/parameters/builds"
+        - $ref: "#/components/parameters/builds_limit"
       responses:
         "200":
           description: >
@@ -1065,6 +1090,11 @@ paths:
         - $ref: "#/components/parameters/wf_uuid"
         - $ref: "#/components/parameters/wf_version"
         - $ref: "#/components/parameters/rocrate_specs"
+        - $ref: "#/components/parameters/wf_status"
+        - $ref: "#/components/parameters/suites"
+        - $ref: "#/components/parameters/instances"
+        - $ref: "#/components/parameters/builds"
+        - $ref: "#/components/parameters/builds_limit"
       responses:
         "200":
           description: >
@@ -1815,7 +1845,7 @@ components:
       schema:
         type: boolean
       description: |
-        `true` to include the list of versions of each workflow
+        `true` to include the list of versions of the workflow
       example: "false"
     wf_subscriptions:
       name: "subscriptions"
@@ -1833,6 +1863,39 @@ components:
       description: |
         `true` to include workflows statistics
       example: "false"
+    builds:
+      name: "builds"
+      in: query
+      schema:
+        type: boolean
+      description: |
+        `true` to include the list of builds associated with the workflow version
+      example: "false"
+    suites:
+      name: "suites"
+      in: query
+      schema:
+        type: boolean
+      description: |
+        `true` to include the list of test suites associated with the workflow version
+      example: "false"
+    instances:
+      name: "instances"
+      in: query
+      schema:
+        type: boolean
+      description: |
+        `true` to include the list of test instances associated with the workflow version
+      example: "false"
+    builds_limit:
+      name: "builds_limit"
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        default: 10
+      description: "Maximum number of builds to include per instance"
+      example: "10"
     page:
       name: "page"
       in: query


### PR DESCRIPTION
This pull request adds enhanced support for including test suite, instance, and build details in workflow-related API responses, and introduces new serialization logic to support this richer data. It also refactors and simplifies some error handling and improves code readability in several places.

**API enhancements for workflow details:**

* Added new optional parameters (`suites`, `instances`, `builds`, `builds_limit`) to multiple workflow-related API controller functions (e.g., `workflows_get`, `workflows_get_latest_version_by_id`, `user_workflows_get`, etc.) to allow clients to request inclusion of test suites, test instances, and build details, with control over build result limits. [[1]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fR174-R175) [[2]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fR194-R200) [[3]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fL235-R277) [[4]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fR324-R336) [[5]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fR353-R354) [[6]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fL333-R368) [[7]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fR389-R390) [[8]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fR405-R408) [[9]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fR476-R477) [[10]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fL447-R491)

**Serialization improvements:**

* Introduced `VersionDetailsBaseSchema` and updated `VersionDetailsSchema` in `serializers.py` to support the new include flags, enabling dynamic inclusion of suites, instances, and builds in serialized workflow version responses. Also centralized logic for generating RO-Crate metadata links. [[1]](diffhunk://#diff-573ae741c93b19df54841285ae16d36aaf937dc0de771a702b2b75467976d976R143-R205) [[2]](diffhunk://#diff-573ae741c93b19df54841285ae16d36aaf937dc0de771a702b2b75467976d976R219-R237) [[3]](diffhunk://#diff-573ae741c93b19df54841285ae16d36aaf937dc0de771a702b2b75467976d976L183-R277)

**Error handling and code readability:**

* Refactored error handling in several places to simplify multi-line statements and improve readability, especially around reporting forbidden or not found errors for suites, instances, and builds. [[1]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fL794-R840) [[2]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fL950-R994) [[3]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fL1045-R1088) [[4]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fL1074-R1115)