### PR TITLE
feat: introduce SSE endpoint for workflow registration job events

### DIFF
--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -626,7 +626,8 @@ def process_workflows_post(body, _registry=None, _submitter_id=None,
         logger.debug("workflows_post. Created workflow '%s' (ver.%s)", w.uuid, w.version)
         clear_cache()
         notify_workflow_version_updates([w], type='sync', delay=2)
-        job.update_status('completed', save=True)
+        if job:
+            job.update_status('completed', save=True)
         return {'uuid': str(w.workflow.uuid), 'wf_version': w.version, 'name': w.name,
                 'meta': {
                     'created': w.workflow.created.timestamp(),

--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -626,6 +626,7 @@ def process_workflows_post(body, _registry=None, _submitter_id=None,
         logger.debug("workflows_post. Created workflow '%s' (ver.%s)", w.uuid, w.version)
         clear_cache()
         notify_workflow_version_updates([w], type='sync', delay=2)
+        job.update_status('completed', save=True)
         return {'uuid': str(w.workflow.uuid), 'wf_version': w.version, 'name': w.name,
                 'meta': {
                     'created': w.workflow.created.timestamp(),

--- a/lifemonitor/api/services.py
+++ b/lifemonitor/api/services.py
@@ -219,6 +219,8 @@ class LifeMonitor:
             except KeyError as e:
                 raise lm_exceptions.SpecificationNotValidException(f"Missing property: {e}")
             w.save()
+            if job:
+                job.update_status('workflow registered', save=True)
             return wv
 
     @classmethod

--- a/lifemonitor/tasks/controller.py
+++ b/lifemonitor/tasks/controller.py
@@ -19,11 +19,11 @@
 # SOFTWARE.
 
 import json
+
 import logging
 import time
 
 import flask
-from flask_login import current_user
 
 from lifemonitor.auth.services import authorized
 from lifemonitor.cache import cache

--- a/lifemonitor/tasks/controller.py
+++ b/lifemonitor/tasks/controller.py
@@ -20,8 +20,10 @@
 
 import json
 import logging
+import time
 
 import flask
+from flask_login import current_user
 
 from lifemonitor.auth.services import authorized
 from lifemonitor.cache import cache
@@ -46,3 +48,52 @@ def get_job_status(job_id: str):
     if not serialized_job_data:
         return f"job ${job_id} not found", 404
     return json.loads(serialized_job_data)
+
+
+@authorized
+@blueprint.route("/<job_id>/events", methods=("GET",))
+def get_job_events(job_id: str):
+    if not utils.validate_job_id(job_id):
+        raise ValueError(f"Invalid job id: {job_id}")
+
+    def event_stream():
+        import json
+        i = 0
+        sleep_interval = 1
+        last_sent_data = None
+        try:
+            while True:
+                serialized_job_data = cache.get(utils.get_job_key(job_id=job_id))
+                if not serialized_job_data:
+                    return f"job ${job_id} not found", 404
+                if serialized_job_data == last_sent_data:
+                    logger.warning("No new data for job %s, sleeping...", job_id)
+                    time.sleep(sleep_interval)
+                    continue
+                job_data = json.loads(serialized_job_data)
+                data = {
+                    "counter": i,
+                    "timestamp": time.time(),
+                    "session_id": current_user.is_anonymous,
+                    "type": "jobUpdate",
+                    "data": job_data
+                }
+                logger.info(f"Sending event data: {job_data['status']}")
+                yield f"data: {json.dumps(data)}\n\n"
+                if job_data.get("status", "") in ["completed", "failed", "canceled"]:
+                    break
+                i += 1
+                time.sleep(sleep_interval)
+        except Exception as e:
+            logger.error(f"Error in event stream for job {job_id}: {str(e)}")
+        logger.info(f"Job {job_id} ended with status: {job_data.get('status', '')}")
+
+    return flask.Response(
+        flask.stream_with_context(event_stream()),
+        mimetype="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",   # <--- IMPORTANT FOR NGINX
+        },
+    )

--- a/lifemonitor/tasks/controller.py
+++ b/lifemonitor/tasks/controller.py
@@ -74,7 +74,6 @@ def get_job_events(job_id: str):
                 data = {
                     "counter": i,
                     "timestamp": time.time(),
-                    "session_id": current_user.is_anonymous,
                     "type": "jobUpdate",
                     "data": job_data
                 }

--- a/lifemonitor/tasks/utils.py
+++ b/lifemonitor/tasks/utils.py
@@ -27,7 +27,7 @@ from lifemonitor.cache import cache
 
 logger = logging.getLogger(__name__)
 
-JOB_CACHE_TIMEOUT = 60
+JOB_CACHE_TIMEOUT = 10 * 60  # in seconds
 
 
 def make_job_id() -> str:


### PR DESCRIPTION
This pull request improves tracking and monitoring of workflow registration jobs, including status updates, event streaming, and cache timeout adjustments.

**Job status tracking improvements:**
* Updated the workflow registration process to set the job status to `'workflow registered'` after successful registration in `register_workflow` (`lifemonitor/api/services.py`).
* Updated the workflow processing logic to set the job status to `'completed'` once the workflow is created in `process_workflows_post` (`lifemonitor/api/controllers.py`).

**Job monitoring and API enhancements:**
* Added a new `/jobs/<job_id>/events` endpoint to provide real-time Server-Sent Events (SSE) streaming of job status updates, allowing clients to monitor job progress live (`lifemonitor/tasks/controller.py`).

**Configuration.**
* Increased the job cache timeout from 1 minute to 10 minutes to ensure job data persists longer for monitoring purposes (`lifemonitor/tasks/utils.py`).