### PR TITLE
feat: workflows filtering

### DIFF
--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -175,9 +175,8 @@ def __filter_workflows_list__(workflows, filter_by_string: Optional[str] = None,
         filter_lower = filter_by_string.lower()
 
         workflows = [wf for wf in workflows if
-                     (filter_lower in (str(wf.uuid) or '').lower() or
-                      filter_lower in (wf.name or '').lower() or
-                      filter_lower in (wf.latest_version.name or '').lower())]
+                     (filter_lower in (str(wf.uuid) or '').lower() or filter_lower
+                      in (wf.name or '').lower() or filter_lower in (wf.latest_version.name or '').lower())]
 
     if filter_by_status:
         filter_status = filter_by_status.lower()

--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -169,6 +169,23 @@ def _get_workflows_list_(page: int = 1, per_page: Optional[int] = None, max_item
     return list(dict.fromkeys(workflows)), page_info
 
 
+def __filter_workflows_list__(workflows, filter_by_string: Optional[str] = None,
+                              filter_by_status: Optional[str] = None):
+    if filter_by_string:
+        filter_lower = filter_by_string.lower()
+
+        workflows = [wf for wf in workflows if
+                     (filter_lower in (str(wf.uuid) or '').lower() or
+                      filter_lower in (wf.name or '').lower() or
+                      filter_lower in (wf.latest_version.name or '').lower())]
+
+    if filter_by_status:
+        filter_status = filter_by_status.lower()
+        workflows = [wf for wf in workflows if wf.latest_version.status and wf.latest_version.status.aggregated_status.lower() == filter_status]
+
+    return workflows
+
+
 @cached(timeout=Timeout.REQUEST)
 def workflows_get(status=False, versions=False, subscriptions=False,
                   suites: bool = False, instances: bool = False,
@@ -176,7 +193,9 @@ def workflows_get(status=False, versions=False, subscriptions=False,
                   page: int = 1, per_page: Optional[int] = None,
                   max_items: Optional[int] = None,
                   only_subscriptions=False,
-                  stats: bool = False):
+                  stats: bool = False,
+                  filter_by_string: Optional[str] = None,
+                  filter_by_status: Optional[str] = None):
     workflows, page_info = _get_workflows_list_(page, per_page, max_items,
                                                 subscriptions, only_subscriptions)
 
@@ -185,6 +204,9 @@ def workflows_get(status=False, versions=False, subscriptions=False,
     subscriptions_of = []
     if subscriptions and current_user and not current_user.is_anonymous:
         subscriptions_of = [current_user]
+
+    if filter_by_string or filter_by_status:
+        workflows = __filter_workflows_list__(workflows, filter_by_string, filter_by_status)
 
     serializer = serializers.ListOfWorkflows(
         workflow_status=status,
@@ -323,9 +345,12 @@ def workflows_rocrate_download(wf_uuid, wf_version):
 def registry_workflows_get(status=False, versions=False, stats=False,
                            suites=False, instances=False,
                            builds=False, builds_limit=1,
+                           filter_by_string: Optional[str] = None,
+                           filter_by_status: Optional[str] = None,
                            page=None, per_page=None, max_items=None):
     page_info = PaginationInfo(page=page, per_page=per_page, max_items=max_items)
     workflows = lm.get_registry_workflows(current_registry, page=page_info)
+    workflows = __filter_workflows_list__(workflows, filter_by_string, filter_by_status)
     logger.debug("workflows_get. Got %s workflows (registry: %s)", len(workflows), current_registry)
     return serializers.ListOfWorkflows(
         workflow_status=status, workflow_versions=versions,
@@ -352,6 +377,8 @@ def registry_user_workflows_get(user_id, status=False, versions=False,
                                 stats=False,
                                 suites=False, instances=False,
                                 builds=False, builds_limit=1,
+                                filter_by_string: Optional[str] = None,
+                                filter_by_status: Optional[str] = None,
                                 page=None, per_page=None, max_items=None):
     if not current_registry:
         return lm_exceptions.report_problem(401, "Unauthorized", detail=messages.no_registry_found)
@@ -360,6 +387,7 @@ def registry_user_workflows_get(user_id, status=False, versions=False,
         page_info = PaginationInfo(page=page, per_page=per_page, max_items=max_items)
         workflows = lm.get_user_registry_workflows(identity.user, current_registry, page=page_info)
         logger.debug("registry_user_workflows_get. Got %s workflows (user: %s)", len(workflows), current_user)
+        workflows = __filter_workflows_list__(workflows, filter_by_string, filter_by_status)
         return serializers.ListOfWorkflows(
             workflow_status=status, workflow_versions=versions,
             statistics=lm.get_workflows_stats(workflows) if stats else None,
@@ -388,6 +416,8 @@ def user_workflows_get(status=False, versions=False, subscriptions=False, only_s
                        stats=False,
                        suites=False, instances=False,
                        builds=False, builds_limit=1,
+                       filter_by_string: Optional[str] = None,
+                       filter_by_status: Optional[str] = None,
                        page=None, per_page=None, max_items=None):
     if not current_user or current_user.is_anonymous:
         return lm_exceptions.report_problem(401, "Unauthorized", detail=messages.no_user_in_session)
@@ -397,6 +427,7 @@ def user_workflows_get(status=False, versions=False, subscriptions=False, only_s
                                       only_subscriptions=only_subscriptions,
                                       include_public=False,
                                       page=page_info)
+    workflows = __filter_workflows_list__(workflows, filter_by_string, filter_by_status)
     logger.debug("user_workflows_get. Got %s workflows (user: %s)", len(workflows), current_user)
     return serializers.ListOfWorkflows(workflow_status=status,
                                        workflow_versions=versions,
@@ -475,6 +506,8 @@ def user_workflow_unsubscribe(wf_uuid):
 def user_registry_workflows_get(registry_uuid, status=False, versions=False,
                                 suites=False, instances=False,
                                 builds=False, build_limit=1,
+                                filter_by_string: Optional[str] = None,
+                                filter_by_status: Optional[str] = None,
                                 page: int = 0, per_page: Optional[int] = None,
                                 max_items: Optional[int] = None):
     if not current_user or current_user.is_anonymous:
@@ -484,6 +517,7 @@ def user_registry_workflows_get(registry_uuid, status=False, versions=False,
         registry = lm.get_workflow_registry_by_uuid(registry_uuid)
         page_info = PaginationInfo(page=page, per_page=per_page, max_items=max_items)
         workflows = lm.get_user_registry_workflows(current_user, registry, page=page_info)
+        workflows = __filter_workflows_list__(workflows, filter_by_string, filter_by_status)
         logger.debug("workflows_get. Got %s workflows (user: %s)", len(workflows), current_user)
         return serializers.ListOfWorkflows(
             workflow_status=status, workflow_versions=versions, include_suites=suites, include_instances=instances,

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -1911,16 +1911,16 @@ components:
       in: query
       schema:
         type: string
-      description: "Filter items by a string contained in their name or description"
-      example: "my workflow"
+      description: "Filter workflows by a string contained in their `uuid` identifier or `name`"
+      example: ""
     filter_by_status:
       name: "filter_by_status"
       in: query
       schema:
         type: string
         enum: [all_passing, some_passing, all_failing, not_available]
-      description: "Filter items by their test status"
-      example: "all_passing"
+      description: "Filter workflows by their aggregated test status"
+      example: ""
     page:
       name: "page"
       in: query

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -451,6 +451,8 @@ paths:
         - $ref: "#/components/parameters/instances"
         - $ref: "#/components/parameters/builds"
         - $ref: "#/components/parameters/builds_limit"
+        - $ref: "#/components/parameters/filter_by_string"
+        - $ref: "#/components/parameters/filter_by_status"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
         - $ref: "#/components/parameters/max_items"
@@ -520,6 +522,8 @@ paths:
         - $ref: "#/components/parameters/instances"
         - $ref: "#/components/parameters/builds"
         - $ref: "#/components/parameters/builds_limit"
+        - $ref: "#/components/parameters/filter_by_string"
+        - $ref: "#/components/parameters/filter_by_status"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
         - $ref: "#/components/parameters/max_items"
@@ -588,6 +592,8 @@ paths:
         - $ref: "#/components/parameters/instances"
         - $ref: "#/components/parameters/builds"
         - $ref: "#/components/parameters/builds_limit"
+        - $ref: "#/components/parameters/filter_by_string"
+        - $ref: "#/components/parameters/filter_by_status"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
         - $ref: "#/components/parameters/max_items"
@@ -659,6 +665,8 @@ paths:
         - $ref: "#/components/parameters/instances"
         - $ref: "#/components/parameters/builds"
         - $ref: "#/components/parameters/builds_limit"
+        - $ref: "#/components/parameters/filter_by_string"
+        - $ref: "#/components/parameters/filter_by_status"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
         - $ref: "#/components/parameters/max_items"
@@ -752,6 +760,8 @@ paths:
         - $ref: "#/components/parameters/instances"
         - $ref: "#/components/parameters/builds"
         - $ref: "#/components/parameters/builds_limit"
+        - $ref: "#/components/parameters/filter_by_string"
+        - $ref: "#/components/parameters/filter_by_status"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
         - $ref: "#/components/parameters/max_items"
@@ -1811,7 +1821,7 @@ components:
       schema:
         type: string
       required: true
-      example: 123e4567-e89b-12d3-a456-426614174000
+      example: 5712af93-9d73-4dab-a047-335c28177307
     wf_version:
       name: "wf_version"
       description: "Workflow version"
@@ -1896,6 +1906,21 @@ components:
         default: 10
       description: "Maximum number of builds to include per instance"
       example: "10"
+    filter_by_string:
+      name: "filter_by_string"
+      in: query
+      schema:
+        type: string
+      description: "Filter items by a string contained in their name or description"
+      example: "my workflow"
+    filter_by_status:
+      name: "filter_by_status"
+      in: query
+      schema:
+        type: string
+        enum: [all_passing, some_passing, all_failing, not_available]
+      description: "Filter items by their test status"
+      example: "all_passing"
     page:
       name: "page"
       in: query


### PR DESCRIPTION
This pull request adds filtering capabilities to the workflow listing endpoints, allowing users to filter workflows by a search string or by workflow status. The changes include both backend logic and API specification updates to support these new query parameters.

**API Enhancements:**

* Added new query parameters `filter_by_string` and `filter_by_status` to the workflow-related endpoints in the OpenAPI specification (`specs/api.yaml`). These parameters allow clients to filter workflows by a substring in their name/description or by their aggregated status. [[1]](diffhunk://#diff-18a22884dd1f4eab99a6c81921d604bd43700f5d6eef7213d33026bce6ea65eeR454-R455) [[2]](diffhunk://#diff-18a22884dd1f4eab99a6c81921d604bd43700f5d6eef7213d33026bce6ea65eeR525-R526) [[3]](diffhunk://#diff-18a22884dd1f4eab99a6c81921d604bd43700f5d6eef7213d33026bce6ea65eeR595-R596) [[4]](diffhunk://#diff-18a22884dd1f4eab99a6c81921d604bd43700f5d6eef7213d33026bce6ea65eeR668-R669) [[5]](diffhunk://#diff-18a22884dd1f4eab99a6c81921d604bd43700f5d6eef7213d33026bce6ea65eeR763-R764) [[6]](diffhunk://#diff-18a22884dd1f4eab99a6c81921d604bd43700f5d6eef7213d33026bce6ea65eeR1909-R1923)

**Backend Filtering Logic:**

* Introduced the `__filter_workflows_list__` function in `lifemonitor/api/controllers.py` to filter workflow lists based on the provided string or status.
* Updated all relevant controller functions (`workflows_get`, `registry_workflows_get`, `registry_user_workflows_get`, `user_workflows_get`, `user_registry_workflows_get`) to accept and process the new filtering parameters, applying the filter logic before serialization. [[1]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fR207-R209) [[2]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fR347-R352) [[3]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fR379-R380) [[4]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fR418-R419) [[5]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fR429) [[6]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fR508-R509) [[7]](diffhunk://#diff-d3c51b296b98c7610c0e71f53e501e1e754e62b64cb576eccaa0ec2db7340b9fR519)
