### PR TITLE
feat(api, serializers): support subscribed workflows filtering and include build links

### DIFF
--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -31,7 +31,7 @@ version: 0.14.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.20.0
+appVersion: 0.20.1
 
 # Chart dependencies
 dependencies:

--- a/lifemonitor/api/controllers.py
+++ b/lifemonitor/api/controllers.py
@@ -63,7 +63,7 @@ def stats_workflows_get():
     workflows = None
     if current_user and not current_user.is_anonymous:
         workflows = lm.get_user_workflows(current_user, include_public=False,
-                                          include_subscriptions=True, only_subscriptions=True)
+                                          include_subscriptions=True, subscriptions_only=True)
     elif current_registry:
         workflows = lm.get_registry_workflows(current_registry)
     else:
@@ -81,7 +81,7 @@ def stats_workflows_status_get():
     workflows = None
     if current_user and not current_user.is_anonymous:
         workflows = lm.get_user_workflows(current_user, include_public=False,
-                                          include_subscriptions=True, only_subscriptions=True)
+                                          include_subscriptions=True, subscriptions_only=True)
     elif current_registry:
         workflows = lm.get_registry_workflows(current_registry)
     else:
@@ -154,7 +154,7 @@ def _get_workflows_list_(page: int = 1, per_page: Optional[int] = None, max_item
             current_user,
             include_subscriptions=subscriptions,
             include_public=True,
-            only_subscriptions=only_subscriptions,
+            subscriptions_only=only_subscriptions,
             page=page_info
         ))
     elif current_registry:
@@ -431,7 +431,8 @@ def registry_user_workflows_post(user_id, body):
 
 @authorized
 @cached(timeout=Timeout.REQUEST)
-def user_workflows_get(status=False, versions=False, subscriptions=False, only_subscriptions: bool = False,
+def user_workflows_get(status=False, versions=False,
+                       subscriptions=False, subscriptions_only: bool = False,
                        stats=False,
                        suites=False, instances=False,
                        builds=False, builds_limit=1,
@@ -443,7 +444,7 @@ def user_workflows_get(status=False, versions=False, subscriptions=False, only_s
     page_info = PaginationInfo(page=page, per_page=per_page, max_items=max_items)
     workflows = lm.get_user_workflows(current_user,
                                       include_subscriptions=subscriptions,
-                                      only_subscriptions=only_subscriptions,
+                                      subscriptions_only=subscriptions_only,
                                       include_public=False,
                                       page=page_info)
     workflows = __filter_workflows_list__(workflows, filter_by_string, filter_by_status)

--- a/lifemonitor/api/serializers.py
+++ b/lifemonitor/api/serializers.py
@@ -499,7 +499,7 @@ class TestInstanceSchema(ResourceMetadataSchema):
             builds = []
             for build in obj.get_test_builds(limit=self.builds_limit):
                 builds.append(BuildSummarySchema(
-                    exclude=('meta', 'links',
+                    exclude=('meta',
                              'suite_uuid', 'instance_uuid',
                              'instance')).dump(build))
             return builds
@@ -589,7 +589,7 @@ class WorkflowStatusSchema(WorkflowVersionSchema):
 
     def get_latest_builds(self, workflow_version):
         try:
-            return BuildSummarySchema(exclude=('meta', 'links', 'instance_uuid'), many=True).dump(
+            return BuildSummarySchema(exclude=('meta', 'instance_uuid'), many=True).dump(
                 workflow_version.status.latest_builds)
         except Exception as e:
             logger.debug(e)
@@ -695,7 +695,7 @@ class WorkflowVersionListItem(WorkflowSchema):
             latest_builds = workflow.latest_version.status.latest_builds
             builds = []
             if latest_builds and len(latest_builds) > 0:
-                builds.append(BuildSummarySchema(exclude=('meta', 'links', 'instance_uuid')).dump(latest_builds[0]))
+                builds.append(BuildSummarySchema(exclude=('meta', 'instance_uuid')).dump(latest_builds[0]))
             return builds
         except Exception as e:
             logger.debug(e)
@@ -841,7 +841,7 @@ class SuiteSchema(ResourceMetadataSchema):
         try:
             builds = []
             for build in obj.get_latest_builds(limit=self.builds_limit):
-                builds.append(BuildSummarySchema(exclude=('meta', 'links')).dump(build))
+                builds.append(BuildSummarySchema(exclude=('meta',)).dump(build))
             return builds
         except Exception as e:
             logger.warning("Unable to extract latest_builds for suite: %r", obj)

--- a/lifemonitor/api/services.py
+++ b/lifemonitor/api/services.py
@@ -584,13 +584,13 @@ class LifeMonitor:
     def get_user_workflows(user: User,
                            include_subscriptions: bool = False,
                            include_public: bool = True,
-                           only_subscriptions: bool = False,
+                           subscriptions_only: bool = False,
                            page: Optional[PaginationInfo] = None) -> List[models.Workflow]:
         # Reference to the list of workflows
         all_workflows = []
 
         # If only_subscriptions is False, we need to collect also workflows from registries
-        if not only_subscriptions:
+        if not subscriptions_only:
 
             # Build a single query combining local workflows and registry workflows
             workflows = models.Workflow.get_user_workflows(user, include_subscriptions=include_subscriptions)

--- a/lifemonitor/static/src/package.json
+++ b/lifemonitor/static/src/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lifemonitor",
     "description": "Workflow Testing Service",
-    "version": "0.20.0",
+    "version": "0.20.1",
     "license": "MIT",
     "author": "CRS4",
     "main": "../dist/js/lifemonitor.min.js",

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -679,6 +679,7 @@ paths:
         - $ref: "#/components/parameters/wf_status"
         - $ref: "#/components/parameters/wf_versions"
         - $ref: "#/components/parameters/wf_subscriptions"
+        - $ref: "#/components/parameters/wf_subscriptions_only"
         - $ref: "#/components/parameters/statistics"
         - $ref: "#/components/parameters/suites"
         - $ref: "#/components/parameters/instances"
@@ -1883,6 +1884,14 @@ components:
         type: boolean
       description: |
         `true` to include subscribed workflows
+      example: "false"
+    wf_subscriptions_only:
+      name: "subscriptions_only"
+      in: query
+      schema:
+        type: boolean
+      description: |
+        `true` to include only subscribed workflows. Ignored if `subscriptions` is not `true`.
       example: "false"
     statistics:
       name: "stats"

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -22,7 +22,7 @@
 openapi: "3.0.0"
 
 info:
-  version: "0.20.0"
+  version: "0.20.1"
   title: "Life Monitor API"
   description: |
     *Workflow sustainability service*
@@ -37,7 +37,11 @@ info:
 servers:
   - url: /
     description: >
-      Version 0.20.0 of API.
+      Version 0.20.1 of API.
+  - url: https://mbp.mep.cloudns.cl:8443/api/
+    description: >
+      Version 0.20.1 of API.
+
 
 tags:
   - name: GitHub Integration


### PR DESCRIPTION
This PR introduces support for returning only subscribed workflows through the API and ensures that build objects always include their related links in the serialization.